### PR TITLE
Add WPF UI with tray icon and watch folder configuration

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,11 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
-      - name: Restore and Publish Project
-        run: dotnet restore && dotnet publish -c Release -r win-x64 --self-contained true -o publish /p:Version=${{ steps.version.outputs.VERSION }}
+      - name: Publish service
+        run: dotnet publish FileMoverService/FileMoverService.csproj -c Release -r win-x64 --self-contained true -o publish-service /p:Version=${{ steps.version.outputs.VERSION }}
+
+      - name: Publish UI
+        run: dotnet publish FileMoverService.UI/FileMoverService.UI.csproj -c Release -r win-x64 --self-contained true -o publish-ui /p:Version=${{ steps.version.outputs.VERSION }}
 
       - name: Install Inno Setup
         run: |

--- a/FileMoverService.UI/App.xaml
+++ b/FileMoverService.UI/App.xaml
@@ -1,0 +1,19 @@
+<Application x:Class="FileMoverService.UI.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:tb="http://www.hardcodet.net/taskbar"
+             ShutdownMode="OnExplicitShutdown">
+    <Application.Resources>
+        <tb:TaskbarIcon x:Key="TrayIcon"
+                        ToolTipText="File Mover Service"
+                        TrayMouseDoubleClick="TrayOpen_Click">
+            <tb:TaskbarIcon.ContextMenu>
+                <ContextMenu>
+                    <MenuItem Header="Open" Click="TrayOpen_Click" FontWeight="Bold" />
+                    <Separator />
+                    <MenuItem Header="Exit" Click="TrayExit_Click" />
+                </ContextMenu>
+            </tb:TaskbarIcon.ContextMenu>
+        </tb:TaskbarIcon>
+    </Application.Resources>
+</Application>

--- a/FileMoverService.UI/App.xaml.cs
+++ b/FileMoverService.UI/App.xaml.cs
@@ -1,0 +1,41 @@
+using System.Windows;
+using Hardcodet.Wpf.TaskbarNotification;
+using Application = System.Windows.Application;
+
+namespace FileMoverService.UI;
+
+public partial class App : Application
+{
+    private TaskbarIcon _trayIcon = null!;
+    private MainWindow? _mainWindow;
+
+    protected override void OnStartup(StartupEventArgs e)
+    {
+        base.OnStartup(e);
+        _trayIcon = (TaskbarIcon)FindResource("TrayIcon");
+        ShowMainWindow();
+    }
+
+    protected override void OnExit(ExitEventArgs e)
+    {
+        _trayIcon.Dispose();
+        base.OnExit(e);
+    }
+
+    internal void ShowMainWindow()
+    {
+        if (_mainWindow == null || !_mainWindow.IsLoaded)
+        {
+            _mainWindow = new MainWindow();
+            _mainWindow.Show();
+        }
+        else
+        {
+            _mainWindow.WindowState = WindowState.Normal;
+            _mainWindow.Activate();
+        }
+    }
+
+    private void TrayOpen_Click(object sender, RoutedEventArgs e) => ShowMainWindow();
+    private void TrayExit_Click(object sender, RoutedEventArgs e) => Shutdown();
+}

--- a/FileMoverService.UI/AssemblyInfo.cs
+++ b/FileMoverService.UI/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly:ThemeInfo(
+    ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
+                                                //(used if a resource is not found in the page,
+                                                // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly   //where the generic resource dictionary is located
+                                                //(used if a resource is not found in the page,
+                                                // app, or any theme specific resource dictionaries)
+)]

--- a/FileMoverService.UI/ConfigService.cs
+++ b/FileMoverService.UI/ConfigService.cs
@@ -1,0 +1,61 @@
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace FileMoverService.UI;
+
+public static class ConfigService
+{
+    private static readonly string ConfigPath = Path.Combine(
+        AppDomain.CurrentDomain.BaseDirectory,
+        "..", "FileMoverService", "appsettings.json");
+
+    private static readonly JsonSerializerOptions WriteOptions = new() { WriteIndented = true };
+
+    public static List<WatchFolderEntry> Load()
+    {
+        if (!File.Exists(ConfigPath))
+            return [];
+
+        var json = File.ReadAllText(ConfigPath);
+        var root = JsonNode.Parse(json);
+        var folders = root?["AppSettings"]?["WatchFolders"]?.AsArray();
+
+        if (folders == null)
+            return [];
+
+        return folders.Select(f => new WatchFolderEntry
+        {
+            SourceFolder = f?["SourceFolder"]?.GetValue<string>() ?? string.Empty,
+            TargetFolder = f?["TargetFolder"]?.GetValue<string>() ?? string.Empty,
+            Extensions = string.Join(", ", f?["Extensions"]?.AsArray()
+                .Select(e => e?.GetValue<string>() ?? string.Empty) ?? [])
+        }).ToList();
+    }
+
+    public static void Save(IEnumerable<WatchFolderEntry> entries)
+    {
+        var json = File.ReadAllText(ConfigPath);
+        var root = JsonNode.Parse(json)!;
+
+        var foldersArray = new JsonArray();
+        foreach (var entry in entries)
+        {
+            var exts = entry.Extensions
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(e => e.StartsWith('.') ? e : $".{e}")
+                .ToList();
+
+            var node = new JsonObject
+            {
+                ["SourceFolder"] = entry.SourceFolder,
+                ["TargetFolder"] = entry.TargetFolder,
+                ["Extensions"] = new JsonArray(exts.Select(e => JsonValue.Create(e)).ToArray())
+            };
+            foldersArray.Add(node);
+        }
+
+        root["AppSettings"]!["WatchFolders"] = foldersArray;
+        File.WriteAllText(ConfigPath, root.ToJsonString(WriteOptions));
+    }
+}

--- a/FileMoverService.UI/FileMoverService.UI.csproj
+++ b/FileMoverService.UI/FileMoverService.UI.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="10.0.8" />
   </ItemGroup>
 
 </Project>

--- a/FileMoverService.UI/FileMoverService.UI.csproj
+++ b/FileMoverService.UI/FileMoverService.UI.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+  </ItemGroup>
+
+</Project>

--- a/FileMoverService.UI/MainWindow.xaml
+++ b/FileMoverService.UI/MainWindow.xaml
@@ -45,17 +45,19 @@
         <Grid DockPanel.Dock="Bottom" Margin="0,10,0,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="8" />
-                <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="8" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            <Button Grid.Column="0" x:Name="StartButton" Content="▶  Start Service" Click="StartService_Click" MinWidth="120" />
-            <Button Grid.Column="2" x:Name="StopButton"  Content="■  Stop Service"  Click="StopService_Click"  MinWidth="120" />
-            <Button Grid.Column="4" Content="Add Row" Click="AddRow_Click" />
-            <Button Grid.Column="6" Content="Save"    Click="Save_Click" />
+            <Button Grid.Column="0" x:Name="ServiceButton" Click="ToggleService_Click" MinWidth="140">
+                <StackPanel Orientation="Horizontal">
+                    <Ellipse x:Name="ServiceIndicator" Width="10" Height="10" VerticalAlignment="Center" Margin="0,0,6,0" />
+                    <TextBlock x:Name="ServiceLabel" VerticalAlignment="Center" />
+                </StackPanel>
+            </Button>
+            <Button Grid.Column="2" Content="Add Row" Click="AddRow_Click" />
+            <Button Grid.Column="4" Content="Save"    Click="Save_Click" />
         </Grid>
 
         <!-- Rows -->

--- a/FileMoverService.UI/MainWindow.xaml
+++ b/FileMoverService.UI/MainWindow.xaml
@@ -8,12 +8,16 @@
 
     <Window.Resources>
         <Style TargetType="Button">
-            <Setter Property="Padding" Value="8,3" />
+            <Setter Property="Padding" Value="8,0" />
             <Setter Property="MinWidth" Value="32" />
+            <Setter Property="Height" Value="26" />
+            <Setter Property="VerticalAlignment" Value="Center" />
         </Style>
         <Style TargetType="TextBox">
+            <Setter Property="Height" Value="26" />
             <Setter Property="VerticalContentAlignment" Value="Center" />
-            <Setter Property="Padding" Value="4,2" />
+            <Setter Property="Padding" Value="4,0" />
+            <Setter Property="VerticalAlignment" Value="Center" />
         </Style>
     </Window.Resources>
 
@@ -38,17 +42,28 @@
         </Grid>
 
         <!-- Bottom buttons -->
-        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
-            <Button Content="Add Row" Click="AddRow_Click" Margin="0,0,8,0" />
-            <Button Content="Save" Click="Save_Click" />
-        </StackPanel>
+        <Grid DockPanel.Dock="Bottom" Margin="0,10,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="8" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="8" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Button Grid.Column="0" x:Name="StartButton" Content="▶  Start Service" Click="StartService_Click" MinWidth="120" />
+            <Button Grid.Column="2" x:Name="StopButton"  Content="■  Stop Service"  Click="StopService_Click"  MinWidth="120" />
+            <Button Grid.Column="4" Content="Add Row" Click="AddRow_Click" />
+            <Button Grid.Column="6" Content="Save"    Click="Save_Click" />
+        </Grid>
 
         <!-- Rows -->
         <ScrollViewer VerticalScrollBarVisibility="Auto">
             <ItemsControl x:Name="FolderList">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate DataType="{x:Type local:WatchFolderEntry}">
-                        <Grid Margin="0,0,0,6">
+                        <Grid Margin="0,0,0,6" Height="26">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="12" />
@@ -67,8 +82,7 @@
                                 </Grid.ColumnDefinitions>
                                 <TextBox Grid.Column="0" Text="{Binding SourceFolder, UpdateSourceTrigger=PropertyChanged}" />
                                 <Button Grid.Column="1" Content="…" Margin="2,0,0,0"
-                                        Tag="{Binding}"
-                                        Click="BrowseSource_Click" />
+                                        Tag="{Binding}" Click="BrowseSource_Click" />
                             </Grid>
 
                             <!-- Target folder -->
@@ -79,8 +93,7 @@
                                 </Grid.ColumnDefinitions>
                                 <TextBox Grid.Column="0" Text="{Binding TargetFolder, UpdateSourceTrigger=PropertyChanged}" />
                                 <Button Grid.Column="1" Content="…" Margin="2,0,0,0"
-                                        Tag="{Binding}"
-                                        Click="BrowseTarget_Click" />
+                                        Tag="{Binding}" Click="BrowseTarget_Click" />
                             </Grid>
 
                             <!-- Extensions -->
@@ -90,8 +103,7 @@
 
                             <!-- Delete -->
                             <Button Grid.Column="6" Content="✕"
-                                    Tag="{Binding}"
-                                    Click="DeleteRow_Click" />
+                                    Tag="{Binding}" Click="DeleteRow_Click" />
                         </Grid>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>

--- a/FileMoverService.UI/MainWindow.xaml
+++ b/FileMoverService.UI/MainWindow.xaml
@@ -1,0 +1,101 @@
+<Window x:Class="FileMoverService.UI.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:FileMoverService.UI"
+        Title="File Mover Service" Height="460" Width="780"
+        MinHeight="300" MinWidth="600"
+        Closing="Window_Closing">
+
+    <Window.Resources>
+        <Style TargetType="Button">
+            <Setter Property="Padding" Value="8,3" />
+            <Setter Property="MinWidth" Value="32" />
+        </Style>
+        <Style TargetType="TextBox">
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="Padding" Value="4,2" />
+        </Style>
+    </Window.Resources>
+
+    <DockPanel Margin="12">
+        <!-- Header -->
+        <TextBlock DockPanel.Dock="Top" Text="Watch Folders" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,10" />
+
+        <!-- Column headers -->
+        <Grid DockPanel.Dock="Top" Margin="0,0,0,4">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="12" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="12" />
+                <ColumnDefinition Width="160" />
+                <ColumnDefinition Width="12" />
+                <ColumnDefinition Width="36" />
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0" Text="Source Folder" Foreground="Gray" FontSize="11" />
+            <TextBlock Grid.Column="2" Text="Target Folder" Foreground="Gray" FontSize="11" />
+            <TextBlock Grid.Column="4" Text="Extensions (comma-separated)" Foreground="Gray" FontSize="11" />
+        </Grid>
+
+        <!-- Bottom buttons -->
+        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="Add Row" Click="AddRow_Click" Margin="0,0,8,0" />
+            <Button Content="Save" Click="Save_Click" />
+        </StackPanel>
+
+        <!-- Rows -->
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <ItemsControl x:Name="FolderList">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate DataType="{x:Type local:WatchFolderEntry}">
+                        <Grid Margin="0,0,0,6">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="12" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="12" />
+                                <ColumnDefinition Width="160" />
+                                <ColumnDefinition Width="12" />
+                                <ColumnDefinition Width="36" />
+                            </Grid.ColumnDefinitions>
+
+                            <!-- Source folder -->
+                            <Grid Grid.Column="0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="30" />
+                                </Grid.ColumnDefinitions>
+                                <TextBox Grid.Column="0" Text="{Binding SourceFolder, UpdateSourceTrigger=PropertyChanged}" />
+                                <Button Grid.Column="1" Content="…" Margin="2,0,0,0"
+                                        Tag="{Binding}"
+                                        Click="BrowseSource_Click" />
+                            </Grid>
+
+                            <!-- Target folder -->
+                            <Grid Grid.Column="2">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="30" />
+                                </Grid.ColumnDefinitions>
+                                <TextBox Grid.Column="0" Text="{Binding TargetFolder, UpdateSourceTrigger=PropertyChanged}" />
+                                <Button Grid.Column="1" Content="…" Margin="2,0,0,0"
+                                        Tag="{Binding}"
+                                        Click="BrowseTarget_Click" />
+                            </Grid>
+
+                            <!-- Extensions -->
+                            <TextBox Grid.Column="4"
+                                     Text="{Binding Extensions, UpdateSourceTrigger=PropertyChanged}"
+                                     ToolTip="e.g. .pdf, .docx, .txt" />
+
+                            <!-- Delete -->
+                            <Button Grid.Column="6" Content="✕"
+                                    Tag="{Binding}"
+                                    Click="DeleteRow_Click" />
+                        </Grid>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+    </DockPanel>
+</Window>

--- a/FileMoverService.UI/MainWindow.xaml.cs
+++ b/FileMoverService.UI/MainWindow.xaml.cs
@@ -1,19 +1,23 @@
 using System.Collections.ObjectModel;
+using System.ServiceProcess;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Forms;
+using Button = System.Windows.Controls.Button;
+using MessageBox = System.Windows.MessageBox;
 
 namespace FileMoverService.UI;
 
 public partial class MainWindow : Window
 {
-    private readonly ObservableCollection<WatchFolderEntry> _entries = [];
+    private const string ServiceName = "TorrentMoverService";
+    private readonly ObservableCollection<WatchFolderEntry> _entries;
 
     public MainWindow()
     {
         InitializeComponent();
         _entries = new ObservableCollection<WatchFolderEntry>(ConfigService.Load());
         FolderList.ItemsSource = _entries;
+        RefreshServiceButtons();
     }
 
     private void AddRow_Click(object sender, RoutedEventArgs e) =>
@@ -21,19 +25,19 @@ public partial class MainWindow : Window
 
     private void DeleteRow_Click(object sender, RoutedEventArgs e)
     {
-        if (((System.Windows.Controls.Button)sender).Tag is WatchFolderEntry entry)
+        if (((Button)sender).Tag is WatchFolderEntry entry)
             _entries.Remove(entry);
     }
 
     private void BrowseSource_Click(object sender, RoutedEventArgs e)
     {
-        if (((System.Windows.Controls.Button)sender).Tag is WatchFolderEntry entry)
+        if (((Button)sender).Tag is WatchFolderEntry entry)
             entry.SourceFolder = BrowseFolder(entry.SourceFolder) ?? entry.SourceFolder;
     }
 
     private void BrowseTarget_Click(object sender, RoutedEventArgs e)
     {
-        if (((System.Windows.Controls.Button)sender).Tag is WatchFolderEntry entry)
+        if (((Button)sender).Tag is WatchFolderEntry entry)
             entry.TargetFolder = BrowseFolder(entry.TargetFolder) ?? entry.TargetFolder;
     }
 
@@ -45,16 +49,69 @@ public partial class MainWindow : Window
             UseDescriptionForTitle = true,
             Description = "Select folder"
         };
-        return dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK
-            ? dialog.SelectedPath
-            : null;
+        return dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK ? dialog.SelectedPath : null;
     }
 
     private void Save_Click(object sender, RoutedEventArgs e)
     {
         ConfigService.Save(_entries);
-        System.Windows.MessageBox.Show("Saved. Restart the service to apply changes.", "File Mover Service",
+        MessageBox.Show("Saved. Restart the service to apply changes.", "File Mover Service",
             MessageBoxButton.OK, MessageBoxImage.Information);
+    }
+
+    private void StartService_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            using var sc = new ServiceController(ServiceName);
+            if (sc.Status != ServiceControllerStatus.Running)
+            {
+                sc.Start();
+                sc.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromSeconds(10));
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Could not start service: {ex.Message}", "File Mover Service",
+                MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+        RefreshServiceButtons();
+    }
+
+    private void StopService_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            using var sc = new ServiceController(ServiceName);
+            if (sc.Status != ServiceControllerStatus.Stopped)
+            {
+                sc.Stop();
+                sc.WaitForStatus(ServiceControllerStatus.Stopped, TimeSpan.FromSeconds(10));
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Could not stop service: {ex.Message}", "File Mover Service",
+                MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+        RefreshServiceButtons();
+    }
+
+    private void RefreshServiceButtons()
+    {
+        try
+        {
+            using var sc = new ServiceController(ServiceName);
+            var running = sc.Status == ServiceControllerStatus.Running;
+            StartButton.IsEnabled = !running;
+            StopButton.IsEnabled = running;
+        }
+        catch
+        {
+            // Service not installed — disable both buttons
+            StartButton.IsEnabled = false;
+            StopButton.IsEnabled = false;
+        }
     }
 
     private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)

--- a/FileMoverService.UI/MainWindow.xaml.cs
+++ b/FileMoverService.UI/MainWindow.xaml.cs
@@ -1,0 +1,65 @@
+using System.Collections.ObjectModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Forms;
+
+namespace FileMoverService.UI;
+
+public partial class MainWindow : Window
+{
+    private readonly ObservableCollection<WatchFolderEntry> _entries = [];
+
+    public MainWindow()
+    {
+        InitializeComponent();
+        _entries = new ObservableCollection<WatchFolderEntry>(ConfigService.Load());
+        FolderList.ItemsSource = _entries;
+    }
+
+    private void AddRow_Click(object sender, RoutedEventArgs e) =>
+        _entries.Add(new WatchFolderEntry());
+
+    private void DeleteRow_Click(object sender, RoutedEventArgs e)
+    {
+        if (((System.Windows.Controls.Button)sender).Tag is WatchFolderEntry entry)
+            _entries.Remove(entry);
+    }
+
+    private void BrowseSource_Click(object sender, RoutedEventArgs e)
+    {
+        if (((System.Windows.Controls.Button)sender).Tag is WatchFolderEntry entry)
+            entry.SourceFolder = BrowseFolder(entry.SourceFolder) ?? entry.SourceFolder;
+    }
+
+    private void BrowseTarget_Click(object sender, RoutedEventArgs e)
+    {
+        if (((System.Windows.Controls.Button)sender).Tag is WatchFolderEntry entry)
+            entry.TargetFolder = BrowseFolder(entry.TargetFolder) ?? entry.TargetFolder;
+    }
+
+    private static string? BrowseFolder(string initialPath)
+    {
+        using var dialog = new FolderBrowserDialog
+        {
+            SelectedPath = initialPath,
+            UseDescriptionForTitle = true,
+            Description = "Select folder"
+        };
+        return dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK
+            ? dialog.SelectedPath
+            : null;
+    }
+
+    private void Save_Click(object sender, RoutedEventArgs e)
+    {
+        ConfigService.Save(_entries);
+        System.Windows.MessageBox.Show("Saved. Restart the service to apply changes.", "File Mover Service",
+            MessageBoxButton.OK, MessageBoxImage.Information);
+    }
+
+    private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+    {
+        e.Cancel = true;
+        Hide();
+    }
+}

--- a/FileMoverService.UI/MainWindow.xaml.cs
+++ b/FileMoverService.UI/MainWindow.xaml.cs
@@ -59,12 +59,17 @@ public partial class MainWindow : Window
             MessageBoxButton.OK, MessageBoxImage.Information);
     }
 
-    private void StartService_Click(object sender, RoutedEventArgs e)
+    private void ToggleService_Click(object sender, RoutedEventArgs e)
     {
         try
         {
             using var sc = new ServiceController(ServiceName);
-            if (sc.Status != ServiceControllerStatus.Running)
+            if (sc.Status == ServiceControllerStatus.Running)
+            {
+                sc.Stop();
+                sc.WaitForStatus(ServiceControllerStatus.Stopped, TimeSpan.FromSeconds(10));
+            }
+            else
             {
                 sc.Start();
                 sc.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromSeconds(10));
@@ -72,26 +77,7 @@ public partial class MainWindow : Window
         }
         catch (Exception ex)
         {
-            MessageBox.Show($"Could not start service: {ex.Message}", "File Mover Service",
-                MessageBoxButton.OK, MessageBoxImage.Error);
-        }
-        RefreshServiceButtons();
-    }
-
-    private void StopService_Click(object sender, RoutedEventArgs e)
-    {
-        try
-        {
-            using var sc = new ServiceController(ServiceName);
-            if (sc.Status != ServiceControllerStatus.Stopped)
-            {
-                sc.Stop();
-                sc.WaitForStatus(ServiceControllerStatus.Stopped, TimeSpan.FromSeconds(10));
-            }
-        }
-        catch (Exception ex)
-        {
-            MessageBox.Show($"Could not stop service: {ex.Message}", "File Mover Service",
+            MessageBox.Show($"Could not change service state: {ex.Message}", "File Mover Service",
                 MessageBoxButton.OK, MessageBoxImage.Error);
         }
         RefreshServiceButtons();
@@ -103,14 +89,17 @@ public partial class MainWindow : Window
         {
             using var sc = new ServiceController(ServiceName);
             var running = sc.Status == ServiceControllerStatus.Running;
-            StartButton.IsEnabled = !running;
-            StopButton.IsEnabled = running;
+            ServiceButton.IsEnabled = true;
+            ServiceIndicator.Fill = running
+                ? System.Windows.Media.Brushes.Green
+                : System.Windows.Media.Brushes.Red;
+            ServiceLabel.Text = running ? "Stop Service" : "Start Service";
         }
         catch
         {
-            // Service not installed — disable both buttons
-            StartButton.IsEnabled = false;
-            StopButton.IsEnabled = false;
+            ServiceButton.IsEnabled = false;
+            ServiceIndicator.Fill = System.Windows.Media.Brushes.Gray;
+            ServiceLabel.Text = "Service unavailable";
         }
     }
 

--- a/FileMoverService.UI/WatchFolderEntry.cs
+++ b/FileMoverService.UI/WatchFolderEntry.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel;
+
+namespace FileMoverService.UI;
+
+public class WatchFolderEntry : INotifyPropertyChanged
+{
+    private string _sourceFolder = string.Empty;
+    private string _targetFolder = string.Empty;
+    private string _extensions = string.Empty;
+
+    public string SourceFolder
+    {
+        get => _sourceFolder;
+        set { _sourceFolder = value; OnPropertyChanged(nameof(SourceFolder)); }
+    }
+
+    public string TargetFolder
+    {
+        get => _targetFolder;
+        set { _targetFolder = value; OnPropertyChanged(nameof(TargetFolder)); }
+    }
+
+    public string Extensions
+    {
+        get => _extensions;
+        set { _extensions = value; OnPropertyChanged(nameof(Extensions)); }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged(string name) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}

--- a/FileMoverService.iss
+++ b/FileMoverService.iss
@@ -1,21 +1,80 @@
-   [Setup]
-   AppName=FileMoverService
-   AppVersion={#AppVersion}
-   DefaultDirName={commonpf}\FileMoverService
-   DefaultGroupName=FileMoverService
-   OutputBaseFilename=FileMoverServiceInstaller
-   Compression=lzma
-   SolidCompression=yes
+#define AppName "File Mover Service"
+#define AppPublisher "benedektothten"
+#define AppExeName "FileMoverService.exe"
+#define UIExeName "FileMoverService.UI.exe"
+#define ServiceName "TorrentMoverService"
 
-   [Files]
-   Source: "publish\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
+[Setup]
+AppId={{B3F2A1D0-4E7C-4F8A-9B2E-1C3D5E6F7A8B}
+AppName={#AppName}
+AppVersion={#AppVersion}
+AppPublisher={#AppPublisher}
+DefaultDirName={autopf}\{#AppName}
+DefaultGroupName={#AppName}
+OutputBaseFilename=FileMoverServiceInstaller
+Compression=lzma
+SolidCompression=yes
+WizardStyle=modern
+PrivilegesRequired=admin
 
-   [Run]
-   Filename: "{app}\FileMoverService.exe"; Parameters: "install"; Flags: runhidden
+; Wizard pages
+SetupIconFile=
+WizardSmallImageFile=
+DisableWelcomePage=no
+DisableReadyPage=no
+DisableProgramGroupPage=no
 
-   [UninstallRun]
-   Filename: "{app}\FileMoverService.exe"; Parameters: "uninstall"; Flags: runhidden
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
 
-   [Icons]
-   Name: "{group}\FileMoverService"; Filename: "{app}\FileMoverService.exe"
-   Name: "{group}\Uninstall FileMoverService"; Filename: "{uninstallexe}"
+[Messages]
+WelcomeLabel1=Welcome to the {#AppName} Setup Wizard
+WelcomeLabel2=This will install {#AppName} {#AppVersion} on your computer.%n%nThe service monitors folders and automatically moves files based on rules you configure.%n%nClick Next to continue.
+FinishedHeadingLabel=Setup complete
+FinishedLabel={#AppName} {#AppVersion} has been installed.%n%nThe configuration UI has been added to your system tray startup. You can find it in the Start Menu or by right-clicking the tray icon.%n%nClick Finish to exit Setup.
+ReadyLabel1=Setup is ready to install {#AppName} {#AppVersion}.
+ReadyLabel2a=Click Install to proceed, or click Back to review your settings.
+
+[Tasks]
+Name: "desktopicon"; Description: "Create a &desktop shortcut for the configuration UI"; GroupDescription: "Additional icons:"; Flags: unchecked
+Name: "startservice"; Description: "&Start the service automatically after installation"; GroupDescription: "Service:"
+
+[Dirs]
+Name: "{app}"
+
+[Files]
+; Windows service
+Source: "publish-service\*"; DestDir: "{app}\service"; Flags: ignoreversion recursesubdirs
+
+; Configuration UI
+Source: "publish-ui\*"; DestDir: "{app}\ui"; Flags: ignoreversion recursesubdirs
+
+; Shared appsettings (written once, not overwritten on upgrade)
+Source: "FileMoverService\appsettings.json"; DestDir: "{app}\service"; Flags: onlyifdoesntexist
+
+[Icons]
+; Start Menu
+Name: "{group}\{#AppName} Configuration"; Filename: "{app}\ui\{#UIExeName}"; Comment: "Configure File Mover Service"
+Name: "{group}\Uninstall {#AppName}";     Filename: "{uninstallexe}"
+
+; Desktop (optional task)
+Name: "{userdesktop}\{#AppName} Configuration"; Filename: "{app}\ui\{#UIExeName}"; Tasks: desktopicon
+
+[Registry]
+; Auto-start UI in system tray on login
+Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; \
+  ValueType: string; ValueName: "{#AppName}"; \
+  ValueData: """{app}\ui\{#UIExeName}"""; \
+  Flags: uninsdeletevalue
+
+[Run]
+; Install and optionally start the Windows service
+Filename: "{app}\service\{#AppExeName}"; Parameters: "install"; Flags: runhidden waituntilterminated; StatusMsg: "Installing Windows service..."
+Filename: "{app}\service\{#AppExeName}"; Parameters: "start";   Flags: runhidden waituntilterminated; StatusMsg: "Starting service..."; Tasks: startservice
+
+; Launch the UI after setup (not elevated, so it runs as the user)
+Filename: "{app}\ui\{#UIExeName}"; Description: "Launch {#AppName} configuration UI"; Flags: nowait postinstall skipifsilent
+
+[UninstallRun]
+Filename: "{app}\service\{#AppExeName}"; Parameters: "stop";      Flags: runhidden waituntilterminated; RunOnceId: "StopService"
+Filename: "{app}\service\{#AppExeName}"; Parameters: "uninstall"; Flags: runhidden waituntilterminated; RunOnceId: "UninstallService"

--- a/FileMoverService.sln
+++ b/FileMoverService.sln
@@ -2,15 +2,44 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileMoverService", "FileMoverService\FileMoverService.csproj", "{3A28F1AA-2155-4DB6-9CC2-38D97B5381FE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileMoverService.UI", "FileMoverService.UI\FileMoverService.UI.csproj", "{4CAE24D3-3688-42F1-9D41-1FF6C0414C9B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{3A28F1AA-2155-4DB6-9CC2-38D97B5381FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3A28F1AA-2155-4DB6-9CC2-38D97B5381FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3A28F1AA-2155-4DB6-9CC2-38D97B5381FE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3A28F1AA-2155-4DB6-9CC2-38D97B5381FE}.Debug|x64.Build.0 = Debug|Any CPU
+		{3A28F1AA-2155-4DB6-9CC2-38D97B5381FE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3A28F1AA-2155-4DB6-9CC2-38D97B5381FE}.Debug|x86.Build.0 = Debug|Any CPU
 		{3A28F1AA-2155-4DB6-9CC2-38D97B5381FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3A28F1AA-2155-4DB6-9CC2-38D97B5381FE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3A28F1AA-2155-4DB6-9CC2-38D97B5381FE}.Release|x64.ActiveCfg = Release|Any CPU
+		{3A28F1AA-2155-4DB6-9CC2-38D97B5381FE}.Release|x64.Build.0 = Release|Any CPU
+		{3A28F1AA-2155-4DB6-9CC2-38D97B5381FE}.Release|x86.ActiveCfg = Release|Any CPU
+		{3A28F1AA-2155-4DB6-9CC2-38D97B5381FE}.Release|x86.Build.0 = Release|Any CPU
+		{4CAE24D3-3688-42F1-9D41-1FF6C0414C9B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4CAE24D3-3688-42F1-9D41-1FF6C0414C9B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4CAE24D3-3688-42F1-9D41-1FF6C0414C9B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4CAE24D3-3688-42F1-9D41-1FF6C0414C9B}.Debug|x64.Build.0 = Debug|Any CPU
+		{4CAE24D3-3688-42F1-9D41-1FF6C0414C9B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4CAE24D3-3688-42F1-9D41-1FF6C0414C9B}.Debug|x86.Build.0 = Debug|Any CPU
+		{4CAE24D3-3688-42F1-9D41-1FF6C0414C9B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4CAE24D3-3688-42F1-9D41-1FF6C0414C9B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4CAE24D3-3688-42F1-9D41-1FF6C0414C9B}.Release|x64.ActiveCfg = Release|Any CPU
+		{4CAE24D3-3688-42F1-9D41-1FF6C0414C9B}.Release|x64.Build.0 = Release|Any CPU
+		{4CAE24D3-3688-42F1-9D41-1FF6C0414C9B}.Release|x86.ActiveCfg = Release|Any CPU
+		{4CAE24D3-3688-42F1-9D41-1FF6C0414C9B}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary

- New `FileMoverService.UI` WPF project added to the solution
- Main window shows a list of watch folder rows — each row has a source folder picker, target folder picker, and a comma-separated extensions text field
- Add row / delete row / save buttons; save writes directly to the service's `appsettings.json`
- Closing the window hides to tray instead of exiting
- Tray icon (via `Hardcodet.NotifyIcon.Wpf`) with Open / Exit context menu, double-click also opens the window

## How it works

The UI is a standalone config editor — it is a separate process from the Windows service. Saving updates `appsettings.json`; the user restarts the service to pick up changes (a future improvement could do this automatically).

## Test plan

- [ ] `dotnet run` from `FileMoverService.UI` opens the main window
- [ ] Path picker buttons open a folder browser dialog
- [ ] Add/delete rows work
- [ ] Save writes the correct JSON to `appsettings.json`
- [ ] Closing the window leaves the tray icon visible
- [ ] Tray → Open re-shows the window; Tray → Exit closes the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)