### PR TITLE
Overhaul UI, fix service control, add dual-installer release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
 
     steps:
-      - name: Checkout Code
+      - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -30,22 +30,67 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
-      - name: Publish service
-        run: dotnet publish FileMoverService/FileMoverService.csproj -c Release -r win-x64 --self-contained true -o publish-service /p:Version=${{ steps.version.outputs.VERSION }}
+      # -----------------------------------------------------------------------
+      # Small installer — framework-dependent (~3 MB, requires .NET 10)
+      # -----------------------------------------------------------------------
 
-      - name: Publish UI
-        run: dotnet publish FileMoverService.UI/FileMoverService.UI.csproj -c Release -r win-x64 --self-contained true -o publish-ui /p:Version=${{ steps.version.outputs.VERSION }}
+      - name: Publish service (framework-dependent)
+        run: >
+          dotnet publish FileMoverService/FileMoverService.csproj
+          -c Release -r win-x64 --self-contained false
+          -o publish-service
+          /p:Version=${{ steps.version.outputs.VERSION }}
+
+      - name: Publish UI (framework-dependent)
+        run: >
+          dotnet publish FileMoverService.UI/FileMoverService.UI.csproj
+          -c Release -r win-x64 --self-contained false
+          -o publish-ui
+          /p:Version=${{ steps.version.outputs.VERSION }}
+
+      # -----------------------------------------------------------------------
+      # Bundled installer — self-contained (~75 MB, .NET included)
+      # -----------------------------------------------------------------------
+
+      - name: Publish service (self-contained)
+        run: >
+          dotnet publish FileMoverService/FileMoverService.csproj
+          -c Release -r win-x64 --self-contained true
+          -o publish-service-bundled
+          /p:Version=${{ steps.version.outputs.VERSION }}
+
+      - name: Publish UI (self-contained)
+        run: >
+          dotnet publish FileMoverService.UI/FileMoverService.UI.csproj
+          -c Release -r win-x64 --self-contained true
+          -o publish-ui-bundled
+          /p:Version=${{ steps.version.outputs.VERSION }}
+
+      # -----------------------------------------------------------------------
+      # Compile both installers
+      # -----------------------------------------------------------------------
 
       - name: Install Inno Setup
         run: |
           curl -L -o innosetup.exe https://jrsoftware.org/download.php/is.exe
           ./innosetup.exe /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
 
-      - name: Build Installer
-        run: |
-          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" `
-            /DAppVersion="${{ steps.version.outputs.VERSION }}" `
-            FileMoverService.iss
+      - name: Compile small installer
+        run: >
+          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+          /DAppVersion="${{ steps.version.outputs.VERSION }}"
+          FileMoverService.iss
+
+      - name: Compile bundled installer
+        run: >
+          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+          /DAppVersion="${{ steps.version.outputs.VERSION }}"
+          /DBundled
+          FileMoverService.iss
+
+      # -----------------------------------------------------------------------
+      # Publish GitHub Release with both files
+      # -----------------------------------------------------------------------
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -53,4 +98,6 @@ jobs:
           tag_name: v${{ steps.version.outputs.VERSION }}
           name: v${{ steps.version.outputs.VERSION }}
           generate_release_notes: true
-          files: Output/FileMoverServiceInstaller.exe
+          files: |
+            Output/FileMoverServiceInstaller.exe
+            Output/FileMoverServiceInstaller-Full.exe

--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,16 @@ DocProject/Help/html
 # Click-Once directory
 publish/
 
+# Claude Code internal instructions
+CLAUDE.md
+
+# Release build artefacts
+publish-service/
+publish-service-bundled/
+publish-ui/
+publish-ui-bundled/
+Output/
+
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml

--- a/FileMoverService.UI/App.xaml
+++ b/FileMoverService.UI/App.xaml
@@ -4,17 +4,25 @@
              xmlns:tb="http://www.hardcodet.net/taskbar"
              ShutdownMode="OnExplicitShutdown">
     <Application.Resources>
-        <tb:TaskbarIcon x:Key="TrayIcon"
-                        x:Name="TrayIcon"
-                        ToolTipText="File Mover Service"
-                        TrayLeftMouseUp="TrayOpen_Click">
-            <tb:TaskbarIcon.ContextMenu>
-                <ContextMenu>
-                    <MenuItem Header="Open" Click="TrayOpen_Click" FontWeight="Bold" />
-                    <Separator />
-                    <MenuItem Header="Exit" Click="TrayExit_Click" />
-                </ContextMenu>
-            </tb:TaskbarIcon.ContextMenu>
-        </tb:TaskbarIcon>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <!-- Light theme loaded first; ThemeManager swaps it at runtime -->
+                <ResourceDictionary Source="Themes/LightTheme.xaml"/>
+                <!-- Control templates that consume the theme brushes via DynamicResource -->
+                <ResourceDictionary Source="Themes/Controls.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <tb:TaskbarIcon x:Key="TrayIcon"
+                            ToolTipText="File Mover Service"
+                            TrayLeftMouseUp="TrayOpen_Click">
+                <tb:TaskbarIcon.ContextMenu>
+                    <ContextMenu>
+                        <MenuItem Header="Open" Click="TrayOpen_Click" FontWeight="Bold"/>
+                        <Separator/>
+                        <MenuItem Header="Exit" Click="TrayExit_Click"/>
+                    </ContextMenu>
+                </tb:TaskbarIcon.ContextMenu>
+            </tb:TaskbarIcon>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/FileMoverService.UI/App.xaml.cs
+++ b/FileMoverService.UI/App.xaml.cs
@@ -1,5 +1,7 @@
 using System.Drawing;
+using System.ServiceProcess;
 using System.Windows;
+using System.Windows.Threading;
 using Hardcodet.Wpf.TaskbarNotification;
 using Application = System.Windows.Application;
 
@@ -13,14 +15,57 @@ public partial class App : Application
     protected override void OnStartup(StartupEventArgs e)
     {
         base.OnStartup(e);
+
+        // Elevated service-control helper: launched by the main instance via runas.
+        // Performs the operation and exits — never shows a window.
+        if (e.Args.Length == 3 && e.Args[0] == "--elevate" && e.Args[1] == "service")
+        {
+            RunElevatedServiceCommand(e.Args[2]);
+            Shutdown();
+            return;
+        }
+
+        DispatcherUnhandledException += (_, ex) =>
+        {
+            Logger.Log("Unhandled exception", ex.Exception);
+            System.Windows.MessageBox.Show(
+                $"Unexpected error: {ex.Exception.Message}\n\nDetails logged to:\n{Logger.LogFilePath}",
+                "File Mover Service", MessageBoxButton.OK, MessageBoxImage.Error);
+            ex.Handled = true;
+        };
+
+        Logger.Log("Application started");
         _trayIcon = (TaskbarIcon)FindResource("TrayIcon");
         _trayIcon.Icon = CreateTrayIcon();
         ShowMainWindow();
     }
 
+    private static void RunElevatedServiceCommand(string command)
+    {
+        try
+        {
+            using var sc = new ServiceController(FileMoverService.UI.MainWindow.ServiceName);
+            switch (command)
+            {
+                case "start":
+                    sc.Start();
+                    sc.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromSeconds(15));
+                    break;
+                case "stop":
+                    sc.Stop();
+                    sc.WaitForStatus(ServiceControllerStatus.Stopped, TimeSpan.FromSeconds(15));
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Log($"Elevated service command '{command}' failed", ex);
+        }
+    }
+
     protected override void OnExit(ExitEventArgs e)
     {
-        _trayIcon.Dispose();
+        _trayIcon?.Dispose();
         base.OnExit(e);
     }
 

--- a/FileMoverService.UI/ConfigService.cs
+++ b/FileMoverService.UI/ConfigService.cs
@@ -6,9 +6,9 @@ namespace FileMoverService.UI;
 
 public static class ConfigService
 {
-    private static readonly string ConfigPath = Path.Combine(
-        AppDomain.CurrentDomain.BaseDirectory,
-        "..", "service", "appsettings.json");
+    internal static readonly string ConfigPath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+        "FileMoverService", "appsettings.json");
 
     private static readonly JsonSerializerOptions WriteOptions = new() { WriteIndented = true };
 
@@ -35,7 +35,10 @@ public static class ConfigService
 
     public static void Save(IEnumerable<WatchFolderEntry> entries)
     {
-        var json = File.ReadAllText(ConfigPath);
+        var resolvedPath = Path.GetFullPath(ConfigPath);
+        Directory.CreateDirectory(Path.GetDirectoryName(resolvedPath)!);
+        Logger.Log($"ConfigService.Save: resolved path = {resolvedPath}, exists = {File.Exists(resolvedPath)}");
+        var json = File.ReadAllText(resolvedPath);
         var root = JsonNode.Parse(json)!;
 
         var foldersArray = new JsonArray();
@@ -56,6 +59,6 @@ public static class ConfigService
         }
 
         root["AppSettings"]!["WatchFolders"] = foldersArray;
-        File.WriteAllText(ConfigPath, root.ToJsonString(WriteOptions));
+        File.WriteAllText(resolvedPath, root.ToJsonString(WriteOptions));
     }
 }

--- a/FileMoverService.UI/Converters.cs
+++ b/FileMoverService.UI/Converters.cs
@@ -1,0 +1,24 @@
+using System.Globalization;
+using System.Windows.Data;
+
+namespace FileMoverService.UI;
+
+/// <summary>Returns true when the AlternationIndex is odd — used with DataTrigger + DynamicResource for zebra rows.</summary>
+public class IsOddConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
+        value is int i && i % 2 == 1;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+/// <summary>Converts a 0-based AlternationIndex to a 1-based row number string.</summary>
+public class IncrementConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
+        value is int i ? (i + 1).ToString() : string.Empty;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}

--- a/FileMoverService.UI/Logger.cs
+++ b/FileMoverService.UI/Logger.cs
@@ -1,0 +1,29 @@
+using System.IO;
+
+namespace FileMoverService.UI;
+
+internal static class Logger
+{
+    private static readonly string LogPath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "FileMoverService", "ui.log");
+
+    static Logger()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(LogPath)!);
+    }
+
+    internal static void Log(string message)
+    {
+        try
+        {
+            File.AppendAllText(LogPath, $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {message}{Environment.NewLine}");
+        }
+        catch { /* never let logging crash the app */ }
+    }
+
+    internal static void Log(string message, Exception ex) =>
+        Log($"{message}: {ex}");
+
+    internal static string LogFilePath => LogPath;
+}

--- a/FileMoverService.UI/MainWindow.xaml
+++ b/FileMoverService.UI/MainWindow.xaml
@@ -2,114 +2,195 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:FileMoverService.UI"
-        Title="File Mover Service" Height="460" Width="780"
-        MinHeight="300" MinWidth="600"
+        Title="File Mover Service" Height="460" Width="820"
+        MinHeight="300" MinWidth="620"
+        Background="{DynamicResource WindowBackground}"
+        Loaded="Window_Loaded"
         Closing="Window_Closing">
 
     <Window.Resources>
-        <Style TargetType="Button">
-            <Setter Property="Padding" Value="8,0" />
-            <Setter Property="MinWidth" Value="32" />
-            <Setter Property="Height" Value="26" />
-            <Setter Property="VerticalAlignment" Value="Center" />
-        </Style>
-        <Style TargetType="TextBox">
-            <Setter Property="Height" Value="26" />
-            <Setter Property="VerticalContentAlignment" Value="Center" />
-            <Setter Property="Padding" Value="4,0" />
-            <Setter Property="VerticalAlignment" Value="Center" />
+        <local:IsOddConverter    x:Key="IsOddConverter"/>
+        <local:IncrementConverter x:Key="IncrementConverter"/>
+
+        <Style x:Key="RowNumber" TargetType="TextBlock">
+            <Setter Property="Foreground"        Value="{DynamicResource ForegroundSecondary}"/>
+            <Setter Property="FontSize"          Value="11"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="HorizontalAlignment" Value="Right"/>
+            <Setter Property="Margin"            Value="0,0,6,0"/>
         </Style>
     </Window.Resources>
 
     <DockPanel Margin="12">
+
         <!-- Header -->
-        <TextBlock DockPanel.Dock="Top" Text="Watch Folders" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,10" />
+        <TextBlock DockPanel.Dock="Top" Text="Watch Folders"
+                   FontSize="16" FontWeight="SemiBold" Margin="0,0,0,10"
+                   Foreground="{DynamicResource ForegroundPrimary}"/>
 
         <!-- Column headers -->
         <Grid DockPanel.Dock="Top" Margin="0,0,0,4">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="12" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="12" />
-                <ColumnDefinition Width="160" />
-                <ColumnDefinition Width="12" />
-                <ColumnDefinition Width="36" />
+                <ColumnDefinition Width="28"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="12"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="12"/>
+                <ColumnDefinition Width="160"/>
+                <ColumnDefinition Width="12"/>
+                <ColumnDefinition Width="32"/>
             </Grid.ColumnDefinitions>
-            <TextBlock Grid.Column="0" Text="Source Folder" Foreground="Gray" FontSize="11" />
-            <TextBlock Grid.Column="2" Text="Target Folder" Foreground="Gray" FontSize="11" />
-            <TextBlock Grid.Column="4" Text="Extensions (comma-separated)" Foreground="Gray" FontSize="11" />
+            <TextBlock Grid.Column="1" Text="Source Folder"                Foreground="{DynamicResource ForegroundSecondary}" FontSize="11"/>
+            <TextBlock Grid.Column="3" Text="Target Folder"                Foreground="{DynamicResource ForegroundSecondary}" FontSize="11"/>
+            <TextBlock Grid.Column="5" Text="Extensions (comma-separated)" Foreground="{DynamicResource ForegroundSecondary}" FontSize="11"/>
         </Grid>
 
-        <!-- Bottom buttons -->
+        <!-- Bottom toolbar -->
         <Grid DockPanel.Dock="Bottom" Margin="0,10,0,0">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="8" />
-                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="8"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="8"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
+
+            <!-- Service toggle -->
             <Button Grid.Column="0" x:Name="ServiceButton" Click="ToggleService_Click" MinWidth="140">
                 <StackPanel Orientation="Horizontal">
-                    <Ellipse x:Name="ServiceIndicator" Width="10" Height="10" VerticalAlignment="Center" Margin="0,0,6,0" />
-                    <TextBlock x:Name="ServiceLabel" VerticalAlignment="Center" />
+                    <Ellipse x:Name="ServiceIndicator" Width="10" Height="10"
+                             VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <TextBlock x:Name="ServiceLabel" VerticalAlignment="Center"/>
                 </StackPanel>
             </Button>
-            <Button Grid.Column="2" Content="Add Row" Click="AddRow_Click" />
-            <Button Grid.Column="4" Content="Save"    Click="Save_Click" />
+
+            <!-- Theme toggle -->
+            <Button Grid.Column="2" x:Name="ThemeToggleButton"
+                    Style="{StaticResource IconButton}"
+                    Click="ThemeToggle_Click"
+                    ToolTip="{DynamicResource ThemeToggleTip}"
+                    FontSize="14">
+                <TextBlock Text="{DynamicResource ThemeToggleIcon}" VerticalAlignment="Center"/>
+            </Button>
+
+            <Button Grid.Column="4" Content="Add Row" Click="AddRow_Click"/>
+            <Button Grid.Column="6" Content="Save" Click="Save_Click"
+                    Style="{StaticResource PrimaryButton}"/>
         </Grid>
 
-        <!-- Rows -->
-        <ScrollViewer VerticalScrollBarVisibility="Auto">
-            <ItemsControl x:Name="FolderList">
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate DataType="{x:Type local:WatchFolderEntry}">
-                        <Grid Margin="0,0,0,6" Height="26">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="12" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="12" />
-                                <ColumnDefinition Width="160" />
-                                <ColumnDefinition Width="12" />
-                                <ColumnDefinition Width="36" />
-                            </Grid.ColumnDefinitions>
+        <!-- Row list + empty state -->
+        <Grid>
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <ItemsControl x:Name="FolderList" AlternationCount="1000">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate DataType="{x:Type local:WatchFolderEntry}">
 
-                            <!-- Source folder -->
-                            <Grid Grid.Column="0">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="30" />
-                                </Grid.ColumnDefinitions>
-                                <TextBox Grid.Column="0" Text="{Binding SourceFolder, UpdateSourceTrigger=PropertyChanged}" />
-                                <Button Grid.Column="1" Content="…" Margin="2,0,0,0"
-                                        Tag="{Binding}" Click="BrowseSource_Click" />
-                            </Grid>
+                            <!-- Border carries the zebra background via DynamicResource + DataTrigger -->
+                            <Border Margin="0,0,0,2" MinHeight="30">
+                                <Border.Style>
+                                    <Style TargetType="Border">
+                                        <Setter Property="Background" Value="{DynamicResource RowBackgroundEven}"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Value="True">
+                                                <DataTrigger.Binding>
+                                                    <Binding RelativeSource="{RelativeSource Self}"
+                                                             Path="(ItemsControl.AlternationIndex)"
+                                                             Converter="{StaticResource IsOddConverter}"/>
+                                                </DataTrigger.Binding>
+                                                <Setter Property="Background" Value="{DynamicResource RowBackgroundOdd}"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
 
-                            <!-- Target folder -->
-                            <Grid Grid.Column="2">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="30" />
-                                </Grid.ColumnDefinitions>
-                                <TextBox Grid.Column="0" Text="{Binding TargetFolder, UpdateSourceTrigger=PropertyChanged}" />
-                                <Button Grid.Column="1" Content="…" Margin="2,0,0,0"
-                                        Tag="{Binding}" Click="BrowseTarget_Click" />
-                            </Grid>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="28"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="12"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="12"/>
+                                        <ColumnDefinition Width="160"/>
+                                        <ColumnDefinition Width="12"/>
+                                        <ColumnDefinition Width="32"/>
+                                    </Grid.ColumnDefinitions>
 
-                            <!-- Extensions -->
-                            <TextBox Grid.Column="4"
-                                     Text="{Binding Extensions, UpdateSourceTrigger=PropertyChanged}"
-                                     ToolTip="e.g. .pdf, .docx, .txt" />
+                                    <!-- Row number -->
+                                    <TextBlock Grid.Column="0" Style="{StaticResource RowNumber}"
+                                               Text="{Binding RelativeSource={RelativeSource Self},
+                                                      Path=(ItemsControl.AlternationIndex),
+                                                      Converter={StaticResource IncrementConverter}}"/>
 
-                            <!-- Delete -->
-                            <Button Grid.Column="6" Content="✕"
-                                    Tag="{Binding}" Click="DeleteRow_Click" />
-                        </Grid>
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
-        </ScrollViewer>
+                                    <!-- Source folder -->
+                                    <Grid Grid.Column="1" Margin="0,2,0,2">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="4"/>
+                                            <ColumnDefinition Width="32"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBox Grid.Column="0"
+                                                 Text="{Binding SourceFolder, UpdateSourceTrigger=PropertyChanged,
+                                                        ValidatesOnNotifyDataErrors=True}"/>
+                                        <Button Grid.Column="2" Content="…"
+                                                Style="{StaticResource IconButton}"
+                                                Tag="{Binding}" Click="BrowseSource_Click"/>
+                                    </Grid>
+
+                                    <!-- Target folder -->
+                                    <Grid Grid.Column="3" Margin="0,2,0,2">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="4"/>
+                                            <ColumnDefinition Width="32"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBox Grid.Column="0"
+                                                 Text="{Binding TargetFolder, UpdateSourceTrigger=PropertyChanged,
+                                                        ValidatesOnNotifyDataErrors=True}"/>
+                                        <Button Grid.Column="2" Content="…"
+                                                Style="{StaticResource IconButton}"
+                                                Tag="{Binding}" Click="BrowseTarget_Click"/>
+                                    </Grid>
+
+                                    <!-- Extensions -->
+                                    <TextBox Grid.Column="5" Margin="0,2,0,2"
+                                             Text="{Binding Extensions, UpdateSourceTrigger=PropertyChanged}"
+                                             ToolTip="e.g. .pdf, .docx, .txt"/>
+
+                                    <!-- Delete -->
+                                    <Button Grid.Column="7" Content="✕"
+                                            Style="{StaticResource IconButton}"
+                                            Tag="{Binding}" Click="DeleteRow_Click"/>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+
+            <!-- Empty state -->
+            <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center"
+                        IsHitTestVisible="False">
+                <StackPanel.Style>
+                    <Style TargetType="StackPanel">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Items.Count, ElementName=FolderList}" Value="0">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </StackPanel.Style>
+                <TextBlock Text="No watch folders configured"
+                           FontSize="15" Foreground="{DynamicResource ForegroundSecondary}"
+                           HorizontalAlignment="Center"/>
+                <TextBlock Text="Click &quot;Add Row&quot; to get started"
+                           FontSize="12" Foreground="{DynamicResource ForegroundSecondary}"
+                           Margin="0,4,0,0" Opacity="0.6"
+                           HorizontalAlignment="Center"/>
+            </StackPanel>
+        </Grid>
+
     </DockPanel>
 </Window>

--- a/FileMoverService.UI/MainWindow.xaml.cs
+++ b/FileMoverService.UI/MainWindow.xaml.cs
@@ -1,4 +1,7 @@
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Diagnostics;
 using System.ServiceProcess;
 using System.Windows;
 using System.Windows.Forms;
@@ -9,16 +12,53 @@ namespace FileMoverService.UI;
 
 public partial class MainWindow : Window
 {
-    private const string ServiceName = "TorrentMoverService";
+    internal const string ServiceName = "FileMoverService";
+    private const string BaseTitle = "File Mover Service";
     private readonly ObservableCollection<WatchFolderEntry> _entries;
+    private bool _isDirty;
 
     public MainWindow()
     {
         InitializeComponent();
         _entries = new ObservableCollection<WatchFolderEntry>(ConfigService.Load());
         FolderList.ItemsSource = _entries;
+
+        _entries.CollectionChanged += OnEntriesChanged;
+        foreach (var e in _entries) e.PropertyChanged += OnEntryPropertyChanged;
+
         RefreshServiceButtons();
     }
+
+    // ── Dirty tracking ────────────────────────────────────────────────────────
+
+    private void OnEntriesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.NewItems != null)
+            foreach (WatchFolderEntry entry in e.NewItems)
+                entry.PropertyChanged += OnEntryPropertyChanged;
+
+        if (e.OldItems != null)
+            foreach (WatchFolderEntry entry in e.OldItems)
+                entry.PropertyChanged -= OnEntryPropertyChanged;
+
+        MarkDirty();
+    }
+
+    private void OnEntryPropertyChanged(object? sender, PropertyChangedEventArgs e) => MarkDirty();
+
+    private void MarkDirty()
+    {
+        _isDirty = true;
+        Title = BaseTitle + " *";
+    }
+
+    private void ClearDirty()
+    {
+        _isDirty = false;
+        Title = BaseTitle;
+    }
+
+    // ── Button handlers ───────────────────────────────────────────────────────
 
     private void AddRow_Click(object sender, RoutedEventArgs e) =>
         _entries.Add(new WatchFolderEntry());
@@ -54,9 +94,21 @@ public partial class MainWindow : Window
 
     private void Save_Click(object sender, RoutedEventArgs e)
     {
-        ConfigService.Save(_entries);
-        MessageBox.Show("Saved. Restart the service to apply changes.", "File Mover Service",
-            MessageBoxButton.OK, MessageBoxImage.Information);
+        try
+        {
+            Logger.Log($"Save clicked. Config path: {ConfigService.ConfigPath}");
+            ConfigService.Save(_entries);
+            Logger.Log("Save succeeded");
+            ClearDirty();
+            MessageBox.Show("Configuration saved.", "File Mover Service",
+                MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+        catch (Exception ex)
+        {
+            Logger.Log("Save failed", ex);
+            MessageBox.Show($"Failed to save: {ex.Message}\n\nDetails logged to:\n{Logger.LogFilePath}",
+                "File Mover Service", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
     }
 
     private void ToggleService_Click(object sender, RoutedEventArgs e)
@@ -64,23 +116,34 @@ public partial class MainWindow : Window
         try
         {
             using var sc = new ServiceController(ServiceName);
-            if (sc.Status == ServiceControllerStatus.Running)
+            var command = sc.Status == ServiceControllerStatus.Running ? "stop" : "start";
+
+            // Start/stop requires admin rights. Relaunch ourselves elevated for just
+            // this operation — UAC shows our own app name rather than cmd.exe.
+            var exe = Environment.ProcessPath ?? Process.GetCurrentProcess().MainModule!.FileName;
+            var psi = new ProcessStartInfo(exe, $"--elevate service {command}")
             {
-                sc.Stop();
-                sc.WaitForStatus(ServiceControllerStatus.Stopped, TimeSpan.FromSeconds(10));
-            }
-            else
-            {
-                sc.Start();
-                sc.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromSeconds(10));
-            }
+                Verb = "runas",
+                UseShellExecute = true
+            };
+
+            ServiceButton.IsEnabled = false;
+            var process = Process.Start(psi);
+            process?.WaitForExit(20_000);
+        }
+        catch (System.ComponentModel.Win32Exception ex) when (ex.NativeErrorCode == 1223)
+        {
+            // User cancelled the UAC prompt — silently ignore
         }
         catch (Exception ex)
         {
             MessageBox.Show($"Could not change service state: {ex.Message}", "File Mover Service",
                 MessageBoxButton.OK, MessageBoxImage.Error);
         }
-        RefreshServiceButtons();
+        finally
+        {
+            RefreshServiceButtons();
+        }
     }
 
     private void RefreshServiceButtons()
@@ -103,8 +166,32 @@ public partial class MainWindow : Window
         }
     }
 
-    private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+    private void Window_Loaded(object sender, RoutedEventArgs e) =>
+        ThemeManager.Initialize(this);
+
+    private void ThemeToggle_Click(object sender, RoutedEventArgs e) =>
+        ThemeManager.Toggle(this);
+
+    private void Window_Closing(object sender, CancelEventArgs e)
     {
+        if (_isDirty)
+        {
+            var result = MessageBox.Show(
+                "You have unsaved changes. Save before closing?",
+                "File Mover Service",
+                MessageBoxButton.YesNoCancel,
+                MessageBoxImage.Warning);
+
+            if (result == MessageBoxResult.Cancel)
+            {
+                e.Cancel = true;
+                return;
+            }
+
+            if (result == MessageBoxResult.Yes)
+                Save_Click(sender, new RoutedEventArgs());
+        }
+
         e.Cancel = true;
         Hide();
     }

--- a/FileMoverService.UI/ThemeManager.cs
+++ b/FileMoverService.UI/ThemeManager.cs
@@ -1,0 +1,113 @@
+using Microsoft.Win32;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Windows;
+using System.Windows.Interop;
+using Application = System.Windows.Application;
+using Window = System.Windows.Window;
+
+namespace FileMoverService.UI;
+
+public static class ThemeManager
+{
+    // ── Win32 dark title bar ─────────────────────────────────────────────────
+    [DllImport("dwmapi.dll")]
+    private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int value, int size);
+    private const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
+
+    // ── Preference persistence ───────────────────────────────────────────────
+    private static readonly string PrefsPath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "FileMoverService", "ui-settings.json");
+
+    public static bool IsDark { get; private set; }
+
+    // ── Public API ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Applies the saved user preference, or falls back to the OS setting.
+    /// Must be called after the window's handle exists (Loaded or SourceInitialized).
+    /// </summary>
+    public static void Initialize(Window window)
+    {
+        IsDark = LoadPreference() ?? IsSystemDarkMode();
+        Apply(window, IsDark, savePreference: false);
+    }
+
+    /// <summary>Toggles between light and dark and saves the preference.</summary>
+    public static void Toggle(Window window)
+    {
+        Apply(window, !IsDark, savePreference: true);
+    }
+
+    // ── Private ──────────────────────────────────────────────────────────────
+
+    private static void Apply(Window window, bool dark, bool savePreference)
+    {
+        IsDark = dark;
+
+        // Swap theme resource dictionary
+        var uri = new Uri($"Themes/{(dark ? "Dark" : "Light")}Theme.xaml", UriKind.Relative);
+        var newDict = new ResourceDictionary { Source = uri };
+
+        var dicts = Application.Current.Resources.MergedDictionaries;
+        var existing = dicts.FirstOrDefault(d =>
+            d.Source?.OriginalString.EndsWith("Theme.xaml") == true);
+        if (existing != null) dicts.Remove(existing);
+        dicts.Insert(0, newDict);   // insert at 0 so Controls.xaml DynamicResources resolve correctly
+
+        // Dark title bar (Windows 10 build 18985+ / Windows 11)
+        SetTitleBar(window, dark);
+
+        // Update window background
+        window.Background = (System.Windows.Media.Brush)Application.Current.Resources["WindowBackground"];
+
+        if (savePreference) SavePreference(dark);
+    }
+
+    private static void SetTitleBar(Window window, bool dark)
+    {
+        try
+        {
+            var hwnd = new WindowInteropHelper(window).Handle;
+            if (hwnd == IntPtr.Zero) return;
+            int value = dark ? 1 : 0;
+            DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, ref value, sizeof(int));
+        }
+        catch { /* older Windows — not critical */ }
+    }
+
+    private static bool IsSystemDarkMode()
+    {
+        try
+        {
+            using var key = Registry.CurrentUser.OpenSubKey(
+                @"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize");
+            return key?.GetValue("AppsUseLightTheme") is int v && v == 0;
+        }
+        catch { return false; }
+    }
+
+    private static bool? LoadPreference()
+    {
+        try
+        {
+            if (!File.Exists(PrefsPath)) return null;
+            var json = File.ReadAllText(PrefsPath);
+            var doc = JsonDocument.Parse(json);
+            return doc.RootElement.GetProperty("darkMode").GetBoolean();
+        }
+        catch { return null; }
+    }
+
+    private static void SavePreference(bool dark)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(PrefsPath)!);
+            File.WriteAllText(PrefsPath, JsonSerializer.Serialize(new { darkMode = dark }));
+        }
+        catch { /* best-effort */ }
+    }
+}

--- a/FileMoverService.UI/Themes/Controls.xaml
+++ b/FileMoverService.UI/Themes/Controls.xaml
@@ -1,0 +1,136 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- ── Button ──────────────────────────────────────────────────────────── -->
+    <ControlTemplate x:Key="FlatButtonTemplate" TargetType="Button">
+        <Border x:Name="border"
+                Background="{DynamicResource ButtonBackground}"
+                BorderBrush="{DynamicResource ButtonBorder}"
+                BorderThickness="1"
+                CornerRadius="3"
+                SnapsToDevicePixels="True">
+            <ContentPresenter HorizontalAlignment="Center"
+                              VerticalAlignment="Center"
+                              Margin="{TemplateBinding Padding}"
+                              RecognizesAccessKey="True" />
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter TargetName="border" Property="Background" Value="{DynamicResource ButtonHoverBackground}"/>
+                <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource ButtonHoverBorder}"/>
+            </Trigger>
+            <Trigger Property="IsPressed" Value="True">
+                <Setter TargetName="border" Property="Background" Value="{DynamicResource ButtonPressedBackground}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter TargetName="border" Property="Opacity" Value="0.4"/>
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="FlatPrimaryButtonTemplate" TargetType="Button">
+        <Border x:Name="border"
+                Background="{DynamicResource PrimaryBackground}"
+                BorderBrush="{DynamicResource PrimaryBorder}"
+                BorderThickness="1"
+                CornerRadius="3"
+                SnapsToDevicePixels="True">
+            <ContentPresenter HorizontalAlignment="Center"
+                              VerticalAlignment="Center"
+                              Margin="{TemplateBinding Padding}"
+                              RecognizesAccessKey="True" />
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter TargetName="border" Property="Background" Value="{DynamicResource PrimaryHoverBackground}"/>
+            </Trigger>
+            <Trigger Property="IsPressed" Value="True">
+                <Setter TargetName="border" Property="Background" Value="{DynamicResource PrimaryPressedBackground}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter TargetName="border" Property="Opacity" Value="0.4"/>
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <!-- Global Button style -->
+    <Style TargetType="Button">
+        <Setter Property="Template"         Value="{StaticResource FlatButtonTemplate}"/>
+        <Setter Property="Foreground"       Value="{DynamicResource ButtonForeground}"/>
+        <Setter Property="Padding"          Value="12,0"/>
+        <Setter Property="MinWidth"         Value="32"/>
+        <Setter Property="Height"           Value="26"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="Cursor"           Value="Hand"/>
+    </Style>
+
+    <!-- Small icon buttons (browse / delete) -->
+    <Style x:Key="IconButton" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+        <Setter Property="Padding"   Value="0"/>
+        <Setter Property="Width"     Value="32"/>
+        <Setter Property="MinWidth"  Value="32"/>
+    </Style>
+
+    <!-- Primary / accent Save button -->
+    <Style x:Key="PrimaryButton" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+        <Setter Property="Template"    Value="{StaticResource FlatPrimaryButtonTemplate}"/>
+        <Setter Property="Foreground"  Value="{DynamicResource PrimaryForeground}"/>
+        <Setter Property="FontWeight"  Value="SemiBold"/>
+        <Setter Property="MinWidth"    Value="80"/>
+    </Style>
+
+    <!-- ── TextBox ─────────────────────────────────────────────────────────── -->
+    <!-- Simple error template: red border only; error message shown as tooltip -->
+    <ControlTemplate x:Key="ValidationErrorTemplate">
+        <Border BorderBrush="#E81123" BorderThickness="1" CornerRadius="3">
+            <AdornedElementPlaceholder/>
+        </Border>
+    </ControlTemplate>
+
+    <Style TargetType="TextBox">
+        <Setter Property="Height"                    Value="26"/>
+        <Setter Property="VerticalContentAlignment"  Value="Center"/>
+        <Setter Property="Padding"                   Value="4,0"/>
+        <Setter Property="VerticalAlignment"         Value="Center"/>
+        <Setter Property="Background"                Value="{DynamicResource TextBoxBackground}"/>
+        <Setter Property="Foreground"                Value="{DynamicResource TextBoxForeground}"/>
+        <Setter Property="CaretBrush"                Value="{DynamicResource TextBoxForeground}"/>
+        <Setter Property="BorderBrush"               Value="{DynamicResource TextBoxBorder}"/>
+        <Setter Property="BorderThickness"           Value="1"/>
+        <Setter Property="Validation.ErrorTemplate"  Value="{StaticResource ValidationErrorTemplate}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TextBox">
+                    <Border x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="3"
+                            SnapsToDevicePixels="True">
+                        <ScrollViewer x:Name="PART_ContentHost"
+                                      Focusable="False"
+                                      Margin="{TemplateBinding Padding}"
+                                      HorizontalScrollBarVisibility="Hidden"
+                                      VerticalScrollBarVisibility="Hidden"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsFocused" Value="True">
+                            <Setter TargetName="border" Property="BorderBrush"
+                                    Value="{DynamicResource TextBoxBorderFocused}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="border" Property="Opacity" Value="0.4"/>
+                        </Trigger>
+                        <Trigger Property="Validation.HasError" Value="True">
+                            <Setter TargetName="border" Property="BorderBrush" Value="#E81123"/>
+                            <Setter Property="ToolTip"
+                                    Value="{Binding RelativeSource={x:Static RelativeSource.Self},
+                                            Path=(Validation.Errors)[0].ErrorContent}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/FileMoverService.UI/Themes/DarkTheme.xaml
+++ b/FileMoverService.UI/Themes/DarkTheme.xaml
@@ -1,0 +1,42 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Window -->
+    <SolidColorBrush x:Key="WindowBackground"          Color="#202020"/>
+
+    <!-- Text -->
+    <SolidColorBrush x:Key="ForegroundPrimary"         Color="#F0F0F0"/>
+    <SolidColorBrush x:Key="ForegroundSecondary"       Color="#AAAAAA"/>
+
+    <!-- Rows -->
+    <SolidColorBrush x:Key="RowBackgroundEven"         Color="#202020"/>
+    <SolidColorBrush x:Key="RowBackgroundOdd"          Color="#2A2A2A"/>
+
+    <!-- TextBox -->
+    <SolidColorBrush x:Key="TextBoxBackground"         Color="#2D2D2D"/>
+    <SolidColorBrush x:Key="TextBoxForeground"         Color="#F0F0F0"/>
+    <SolidColorBrush x:Key="TextBoxBorder"             Color="#555555"/>
+    <SolidColorBrush x:Key="TextBoxBorderFocused"      Color="#0078D4"/>
+
+    <!-- Button -->
+    <SolidColorBrush x:Key="ButtonBackground"          Color="#3C3C3C"/>
+    <SolidColorBrush x:Key="ButtonForeground"          Color="#F0F0F0"/>
+    <SolidColorBrush x:Key="ButtonBorder"              Color="#555555"/>
+    <SolidColorBrush x:Key="ButtonHoverBackground"     Color="#4A4A4A"/>
+    <SolidColorBrush x:Key="ButtonHoverBorder"         Color="#777777"/>
+    <SolidColorBrush x:Key="ButtonPressedBackground"   Color="#333333"/>
+
+    <!-- Primary (Save) button — same blue, works on both themes -->
+    <SolidColorBrush x:Key="PrimaryBackground"         Color="#0078D4"/>
+    <SolidColorBrush x:Key="PrimaryForeground"         Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="PrimaryBorder"             Color="#005A9E"/>
+    <SolidColorBrush x:Key="PrimaryHoverBackground"    Color="#106EBE"/>
+    <SolidColorBrush x:Key="PrimaryPressedBackground"  Color="#005A9E"/>
+
+    <!-- Theme toggle icon: moon = currently dark -->
+    <system:String x:Key="ThemeToggleIcon"
+                   xmlns:system="clr-namespace:System;assembly=mscorlib">☾</system:String>
+    <system:String x:Key="ThemeToggleTip"
+                   xmlns:system="clr-namespace:System;assembly=mscorlib">Switch to light mode</system:String>
+
+</ResourceDictionary>

--- a/FileMoverService.UI/Themes/LightTheme.xaml
+++ b/FileMoverService.UI/Themes/LightTheme.xaml
@@ -1,0 +1,42 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Window -->
+    <SolidColorBrush x:Key="WindowBackground"          Color="#F3F3F3"/>
+
+    <!-- Text -->
+    <SolidColorBrush x:Key="ForegroundPrimary"         Color="#1E1E1E"/>
+    <SolidColorBrush x:Key="ForegroundSecondary"       Color="#767676"/>
+
+    <!-- Rows -->
+    <SolidColorBrush x:Key="RowBackgroundEven"         Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="RowBackgroundOdd"          Color="#F7F7F7"/>
+
+    <!-- TextBox -->
+    <SolidColorBrush x:Key="TextBoxBackground"         Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="TextBoxForeground"         Color="#1E1E1E"/>
+    <SolidColorBrush x:Key="TextBoxBorder"             Color="#ABADB3"/>
+    <SolidColorBrush x:Key="TextBoxBorderFocused"      Color="#0078D4"/>
+
+    <!-- Button -->
+    <SolidColorBrush x:Key="ButtonBackground"          Color="#FDFDFD"/>
+    <SolidColorBrush x:Key="ButtonForeground"          Color="#1E1E1E"/>
+    <SolidColorBrush x:Key="ButtonBorder"              Color="#D1D1D1"/>
+    <SolidColorBrush x:Key="ButtonHoverBackground"     Color="#F0F0F0"/>
+    <SolidColorBrush x:Key="ButtonHoverBorder"         Color="#BEBEBE"/>
+    <SolidColorBrush x:Key="ButtonPressedBackground"   Color="#E5E5E5"/>
+
+    <!-- Primary (Save) button -->
+    <SolidColorBrush x:Key="PrimaryBackground"         Color="#0078D4"/>
+    <SolidColorBrush x:Key="PrimaryForeground"         Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="PrimaryBorder"             Color="#005A9E"/>
+    <SolidColorBrush x:Key="PrimaryHoverBackground"    Color="#106EBE"/>
+    <SolidColorBrush x:Key="PrimaryPressedBackground"  Color="#005A9E"/>
+
+    <!-- Theme toggle icon: sun = currently light -->
+    <system:String x:Key="ThemeToggleIcon"
+                   xmlns:system="clr-namespace:System;assembly=mscorlib">☀</system:String>
+    <system:String x:Key="ThemeToggleTip"
+                   xmlns:system="clr-namespace:System;assembly=mscorlib">Switch to dark mode</system:String>
+
+</ResourceDictionary>

--- a/FileMoverService.UI/WatchFolderEntry.cs
+++ b/FileMoverService.UI/WatchFolderEntry.cs
@@ -1,8 +1,10 @@
+using System.Collections;
 using System.ComponentModel;
+using System.IO;
 
 namespace FileMoverService.UI;
 
-public class WatchFolderEntry : INotifyPropertyChanged
+public class WatchFolderEntry : INotifyPropertyChanged, INotifyDataErrorInfo
 {
     private string _sourceFolder = string.Empty;
     private string _targetFolder = string.Empty;
@@ -11,13 +13,23 @@ public class WatchFolderEntry : INotifyPropertyChanged
     public string SourceFolder
     {
         get => _sourceFolder;
-        set { _sourceFolder = value; OnPropertyChanged(nameof(SourceFolder)); }
+        set
+        {
+            _sourceFolder = value;
+            OnPropertyChanged(nameof(SourceFolder));
+            Validate(nameof(SourceFolder), value);
+        }
     }
 
     public string TargetFolder
     {
         get => _targetFolder;
-        set { _targetFolder = value; OnPropertyChanged(nameof(TargetFolder)); }
+        set
+        {
+            _targetFolder = value;
+            OnPropertyChanged(nameof(TargetFolder));
+            Validate(nameof(TargetFolder), value);
+        }
     }
 
     public string Extensions
@@ -26,6 +38,33 @@ public class WatchFolderEntry : INotifyPropertyChanged
         set { _extensions = value; OnPropertyChanged(nameof(Extensions)); }
     }
 
+    // ── INotifyPropertyChanged ────────────────────────────────────────────────
     public event PropertyChangedEventHandler? PropertyChanged;
-    private void OnPropertyChanged(string name) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    private void OnPropertyChanged(string name) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+
+    // ── INotifyDataErrorInfo ──────────────────────────────────────────────────
+    private readonly Dictionary<string, List<string>> _errors = [];
+
+    public bool HasErrors => _errors.Count > 0;
+    public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
+
+    public IEnumerable GetErrors(string? propertyName)
+    {
+        if (propertyName is null) return _errors.Values.SelectMany(e => e);
+        return _errors.TryGetValue(propertyName, out var list) ? list : [];
+    }
+
+    private void Validate(string property, string value)
+    {
+        _errors.Remove(property);
+
+        if (string.IsNullOrWhiteSpace(value))
+            _errors[property] = ["Path cannot be empty."];
+        else if (!Directory.Exists(value))
+            _errors[property] = ["Folder does not exist."];
+
+        ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(property));
+        OnPropertyChanged(nameof(HasErrors));
+    }
 }

--- a/FileMoverService.iss
+++ b/FileMoverService.iss
@@ -2,7 +2,22 @@
 #define AppPublisher "benedektothten"
 #define AppExeName "FileMoverService.exe"
 #define UIExeName "FileMoverService.UI.exe"
-#define ServiceName "TorrentMoverService"
+#define ServiceName "FileMoverService"
+
+; ── Variant selection ──────────────────────────────────────────────────────────
+; Pass /DBundled to ISCC to produce the self-contained installer.
+; Without it you get the small framework-dependent installer.
+#ifdef Bundled
+  #define ServiceSourceDir "publish-service-bundled"
+  #define UISourceDir      "publish-ui-bundled"
+  #define OutputFile       "FileMoverServiceInstaller-Full"
+  #define VariantSuffix    " (Includes .NET Runtime)"
+#else
+  #define ServiceSourceDir "publish-service"
+  #define UISourceDir      "publish-ui"
+  #define OutputFile       "FileMoverServiceInstaller"
+  #define VariantSuffix    ""
+#endif
 
 [Setup]
 AppId={{B3F2A1D0-4E7C-4F8A-9B2E-1C3D5E6F7A8B}
@@ -11,13 +26,12 @@ AppVersion={#AppVersion}
 AppPublisher={#AppPublisher}
 DefaultDirName={autopf}\{#AppName}
 DefaultGroupName={#AppName}
-OutputBaseFilename=FileMoverServiceInstaller
+OutputBaseFilename={#OutputFile}
 Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
 PrivilegesRequired=admin
 
-; Wizard pages
 SetupIconFile=
 WizardSmallImageFile=
 DisableWelcomePage=no
@@ -29,35 +43,34 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Messages]
 WelcomeLabel1=Welcome to the {#AppName} Setup Wizard
-WelcomeLabel2=This will install {#AppName} {#AppVersion} on your computer.%n%nThe service monitors folders and automatically moves files based on rules you configure.%n%nClick Next to continue.
+WelcomeLabel2=This will install {#AppName} {#AppVersion}{#VariantSuffix} on your computer.%n%nThe service monitors folders and automatically moves files based on rules you configure.%n%nClick Next to continue.
 FinishedHeadingLabel=Setup complete
 FinishedLabel={#AppName} {#AppVersion} has been installed.%n%nThe configuration UI has been added to your system tray startup. You can find it in the Start Menu or by right-clicking the tray icon.%n%nClick Finish to exit Setup.
-ReadyLabel1=Setup is ready to install {#AppName} {#AppVersion}.
+ReadyLabel1=Setup is ready to install {#AppName} {#AppVersion}{#VariantSuffix}.
 ReadyLabel2a=Click Install to proceed, or click Back to review your settings.
 
 [Tasks]
-Name: "desktopicon"; Description: "Create a &desktop shortcut for the configuration UI"; GroupDescription: "Additional icons:"; Flags: unchecked
-Name: "startservice"; Description: "&Start the service automatically after installation"; GroupDescription: "Service:"
+Name: "desktopicon";  Description: "Create a &desktop shortcut for the configuration UI"; GroupDescription: "Additional icons:"; Flags: unchecked
+Name: "startservice"; Description: "&Start the service automatically after installation";  GroupDescription: "Service:"
 
 [Dirs]
 Name: "{app}"
+; Grant standard users modify rights so the UI can write appsettings.json without elevation
+Name: "{commonappdata}\FileMoverService"; Permissions: users-modify
 
 [Files]
 ; Windows service
-Source: "publish-service\*"; DestDir: "{app}\service"; Flags: ignoreversion recursesubdirs
+Source: "{#ServiceSourceDir}\*"; DestDir: "{app}\service"; Flags: ignoreversion recursesubdirs
 
 ; Configuration UI
-Source: "publish-ui\*"; DestDir: "{app}\ui"; Flags: ignoreversion recursesubdirs
+Source: "{#UISourceDir}\*"; DestDir: "{app}\ui"; Flags: ignoreversion recursesubdirs
 
-; Shared appsettings (written once, not overwritten on upgrade)
-Source: "FileMoverService\appsettings.json"; DestDir: "{app}\service"; Flags: onlyifdoesntexist
+; Shared config in ProgramData — written once, never overwritten on upgrade or uninstall
+Source: "FileMoverService\appsettings.json"; DestDir: "{commonappdata}\FileMoverService"; Flags: onlyifdoesntexist uninsneveruninstall
 
 [Icons]
-; Start Menu
 Name: "{group}\{#AppName} Configuration"; Filename: "{app}\ui\{#UIExeName}"; Comment: "Configure File Mover Service"
 Name: "{group}\Uninstall {#AppName}";     Filename: "{uninstallexe}"
-
-; Desktop (optional task)
 Name: "{userdesktop}\{#AppName} Configuration"; Filename: "{app}\ui\{#UIExeName}"; Tasks: desktopicon
 
 [Registry]
@@ -68,13 +81,49 @@ Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; \
   Flags: uninsdeletevalue
 
 [Run]
-; Install and optionally start the Windows service
 Filename: "{app}\service\{#AppExeName}"; Parameters: "install"; Flags: runhidden waituntilterminated; StatusMsg: "Installing Windows service..."
 Filename: "{app}\service\{#AppExeName}"; Parameters: "start";   Flags: runhidden waituntilterminated; StatusMsg: "Starting service..."; Tasks: startservice
-
-; Launch the UI after setup (not elevated, so it runs as the user)
 Filename: "{app}\ui\{#UIExeName}"; Description: "Launch {#AppName} configuration UI"; Flags: nowait postinstall skipifsilent
 
 [UninstallRun]
 Filename: "{app}\service\{#AppExeName}"; Parameters: "stop";      Flags: runhidden waituntilterminated; RunOnceId: "StopService"
 Filename: "{app}\service\{#AppExeName}"; Parameters: "uninstall"; Flags: runhidden waituntilterminated; RunOnceId: "UninstallService"
+
+[Code]
+// ── .NET check — skipped in the bundled variant ───────────────────────────────
+#ifndef Bundled
+function IsDotNet10Installed(): Boolean;
+var
+  runtimes: TArrayOfString;
+  i: Integer;
+  key: String;
+begin
+  Result := False;
+  key := 'SOFTWARE\dotnet\Setup\InstalledVersions\x64\sharedfx\Microsoft.WindowsDesktop.App';
+  if RegGetValueNames(HKLM, key, runtimes) then
+    for i := 0 to GetArrayLength(runtimes) - 1 do
+      if Pos('10.', runtimes[i]) = 1 then
+      begin
+        Result := True;
+        Exit;
+      end;
+end;
+
+function InitializeSetup(): Boolean;
+var
+  errCode: Integer;
+begin
+  Result := True;
+  if not IsDotNet10Installed() then
+  begin
+    if MsgBox(
+      '.NET Desktop Runtime 10 was not detected on this machine.' + #13#10 + #13#10 +
+      'Please download and install it from:' + #13#10 +
+      'https://aka.ms/dotnet/10/dotnet-runtime-win-x64.exe' + #13#10 + #13#10 +
+      'Click OK to open the download page, or Cancel to quit setup.',
+      mbError, MB_OKCANCEL) = IDOK then
+      ShellExec('open', 'https://aka.ms/dotnet/10/dotnet-runtime-win-x64.exe', '', '', SW_SHOW, ewNoWait, errCode);
+    Result := False;
+  end;
+end;
+#endif

--- a/FileMoverService/FileMonitorService.cs
+++ b/FileMoverService/FileMonitorService.cs
@@ -1,41 +1,79 @@
 using Microsoft.Extensions.Options;
+using System.Threading;
 
 namespace FileMoverService;
 
 public class FileMonitorService : BackgroundService
 {
     private readonly ILogger<FileMonitorService> _logger;
-    private readonly List<FileSystemWatcher> _watchers = [];
-    private readonly AppSettings _settings;
-
+    private readonly IOptionsMonitor<AppSettings> _optionsMonitor;
     private readonly SemaphoreSlim _semaphore = new(2);
+    private readonly Lock _watcherLock = new();
+    private List<FileSystemWatcher> _watchers = [];
+    private IDisposable? _changeListener;
 
     public FileMonitorService(
         ILogger<FileMonitorService> logger,
-        IOptions<AppSettings> settings)
+        IOptionsMonitor<AppSettings> optionsMonitor)
     {
         _logger = logger;
-        _settings = settings.Value;
+        _optionsMonitor = optionsMonitor;
+    }
 
-        foreach (var watchFolder in _settings.WatchFolders)
+    public override Task StartAsync(CancellationToken cancellationToken)
+    {
+        RebuildWatchers(_optionsMonitor.CurrentValue);
+        _changeListener = _optionsMonitor.OnChange(settings =>
         {
-            if (!Directory.Exists(watchFolder.SourceFolder))
+            _logger.LogInformation("Configuration changed, reloading watchers...");
+            RebuildWatchers(settings);
+        });
+        return base.StartAsync(cancellationToken);
+    }
+
+    public override Task StopAsync(CancellationToken cancellationToken)
+    {
+        _changeListener?.Dispose();
+        DisposeWatchers();
+        return base.StopAsync(cancellationToken);
+    }
+
+    private void RebuildWatchers(AppSettings settings)
+    {
+        lock (_watcherLock)
+        {
+            DisposeWatchers();
+            _watchers = [];
+
+            foreach (var watchFolder in settings.WatchFolders)
             {
-                _logger.LogWarning("Watch folder does not exist, skipping: {Folder}", watchFolder.SourceFolder);
-                continue;
+                if (!Directory.Exists(watchFolder.SourceFolder))
+                {
+                    _logger.LogWarning("Watch folder does not exist, skipping: {Folder}", watchFolder.SourceFolder);
+                    continue;
+                }
+
+                var watcher = new FileSystemWatcher(watchFolder.SourceFolder)
+                {
+                    NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite,
+                    EnableRaisingEvents = true
+                };
+
+                watcher.Created += (s, e) => Task.Run(() => OnFileSystemEventAsync(s, e, watchFolder));
+                watcher.Renamed += (s, e) => Task.Run(() => OnFileSystemEventAsync(s, e, watchFolder));
+
+                _watchers.Add(watcher);
+                _logger.LogInformation("Watching folder: {Source} -> {Target}", watchFolder.SourceFolder, watchFolder.TargetFolder);
             }
+        }
+    }
 
-            var watcher = new FileSystemWatcher(watchFolder.SourceFolder)
-            {
-                NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite,
-                EnableRaisingEvents = true
-            };
-
-            watcher.Created += (s, e) => Task.Run(() => OnFileSystemEventAsync(s, e, watchFolder));
-            watcher.Renamed += (s, e) => Task.Run(() => OnFileSystemEventAsync(s, e, watchFolder));
-
-            _watchers.Add(watcher);
-            _logger.LogInformation("Watching folder: {Source} -> {Target}", watchFolder.SourceFolder, watchFolder.TargetFolder);
+    private void DisposeWatchers()
+    {
+        foreach (var watcher in _watchers)
+        {
+            watcher.EnableRaisingEvents = false;
+            watcher.Dispose();
         }
     }
 
@@ -78,7 +116,7 @@ public class FileMonitorService : BackgroundService
     }
 
     private bool IsTemporaryFile(FileInfo fileInfo) =>
-        _settings.TempExtensions.Contains(fileInfo.Extension) || fileInfo.Length < 1024;
+        _optionsMonitor.CurrentValue.TempExtensions.Contains(fileInfo.Extension) || fileInfo.Length < 1024;
 
     private bool IsFileLocked(FileInfo file)
     {

--- a/FileMoverService/Program.cs
+++ b/FileMoverService/Program.cs
@@ -3,6 +3,13 @@ using Topshelf;
 
 var builder = Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder(args);
 
+// Load config from %ProgramData%\FileMoverService\appsettings.json so both the
+// service and the UI read/write the same file without needing elevated rights.
+var sharedConfigPath = Path.Combine(
+    Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+    "FileMoverService", "appsettings.json");
+builder.Configuration.AddJsonFile(sharedConfigPath, optional: true, reloadOnChange: true);
+
 // Configure services
 builder.Services.AddSingleton<IHostedService, FileMonitorService>();
 builder.Services.Configure<AppSettings>(
@@ -30,9 +37,9 @@ HostFactory.Run(configurator =>
 
     // Service Configuration
     configurator.RunAsLocalSystem();
-    configurator.SetServiceName("TorrentMoverService");
-    configurator.SetDisplayName("Torrent Mover Service");
-    configurator.SetDescription("Automatically moves downloaded torrent files");
+    configurator.SetServiceName("FileMoverService");
+    configurator.SetDisplayName("File Mover Service");
+    configurator.SetDescription("Automatically moves files based on configured rules.");
 
     // Startup Type
     configurator.StartAutomatically();

--- a/build-release.ps1
+++ b/build-release.ps1
@@ -1,0 +1,130 @@
+<#
+.SYNOPSIS
+    Builds both installer variants for File Mover Service.
+
+.PARAMETER Version
+    Semantic version string written into the installers (e.g. 1.2.3).
+
+.PARAMETER SkipSmall
+    Skip building the small (framework-dependent) installer.
+
+.PARAMETER SkipBundled
+    Skip building the bundled (self-contained, includes .NET) installer.
+
+.EXAMPLE
+    .\build-release.ps1 -Version 1.0.0
+    Builds both installers into .\Output\
+        FileMoverServiceInstaller.exe       (~3 MB, requires .NET 10)
+        FileMoverServiceInstaller-Full.exe  (~80 MB, .NET included)
+#>
+param(
+    [Parameter(Mandatory)]
+    [string]$Version,
+
+    [switch]$SkipSmall,
+    [switch]$SkipBundled
+)
+
+$ErrorActionPreference = "Stop"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+function Step([string]$msg) {
+    Write-Host ""
+    Write-Host ">>> $msg" -ForegroundColor Cyan
+}
+
+function Require([string]$tool, [string]$hint) {
+    if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) {
+        Write-Host "ERROR: '$tool' not found.  $hint" -ForegroundColor Red
+        exit 1
+    }
+}
+
+function Invoke-Dotnet([string]$cmd) {
+    cmd /c "dotnet $cmd"
+    if ($LASTEXITCODE -ne 0) { throw "dotnet $($cmd.Split(' ')[0]) failed (exit $LASTEXITCODE)" }
+}
+
+# ---------------------------------------------------------------------------
+# Prerequisites
+# ---------------------------------------------------------------------------
+
+Require "dotnet" "Install the .NET SDK from https://dot.net"
+
+$iscc = "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+if (-not (Test-Path $iscc)) {
+    Write-Host "ERROR: Inno Setup 6 not found at '$iscc'." -ForegroundColor Red
+    Write-Host "       Download from https://jrsoftware.org/isdl.php"
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Clean
+# ---------------------------------------------------------------------------
+
+Step "Cleaning previous build artefacts"
+
+foreach ($folder in @("publish-service", "publish-ui", "publish-service-bundled", "publish-ui-bundled")) {
+    if (Test-Path $folder) {
+        Remove-Item $folder -Recurse -Force
+        Write-Host "  Removed $folder"
+    }
+}
+
+New-Item -ItemType Directory -Force -Path "Output" | Out-Null
+
+# ---------------------------------------------------------------------------
+# Publish
+# ---------------------------------------------------------------------------
+
+$serviceProj = "FileMoverService\FileMoverService.csproj"
+$uiProj      = "FileMoverService.UI\FileMoverService.UI.csproj"
+$rid         = "win-x64"
+$config      = "Release"
+
+if (-not $SkipSmall) {
+    Step "Publishing framework-dependent (small installer)"
+    Invoke-Dotnet "publish `"$serviceProj`" -c $config -r $rid --self-contained false -o publish-service"
+    Invoke-Dotnet "publish `"$uiProj`"      -c $config -r $rid --self-contained false -o publish-ui"
+}
+
+if (-not $SkipBundled) {
+    Step "Publishing self-contained (bundled installer)"
+    Invoke-Dotnet "publish `"$serviceProj`" -c $config -r $rid --self-contained true -o publish-service-bundled"
+    Invoke-Dotnet "publish `"$uiProj`"      -c $config -r $rid --self-contained true -o publish-ui-bundled"
+}
+
+# ---------------------------------------------------------------------------
+# Compile installers
+# ---------------------------------------------------------------------------
+
+$isccBase = "/DAppVersion=$Version"
+
+if (-not $SkipSmall) {
+    Step "Compiling small installer  ->  FileMoverServiceInstaller.exe"
+    & $iscc $isccBase "FileMoverService.iss"
+    if ($LASTEXITCODE -ne 0) { Write-Host "Inno Setup failed." -ForegroundColor Red; exit 1 }
+}
+
+if (-not $SkipBundled) {
+    Step "Compiling bundled installer  ->  FileMoverServiceInstaller-Full.exe"
+    & $iscc $isccBase "/DBundled" "FileMoverService.iss"
+    if ($LASTEXITCODE -ne 0) { Write-Host "Inno Setup failed." -ForegroundColor Red; exit 1 }
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+Step "Build complete"
+Write-Host ""
+
+Get-ChildItem "Output\FileMoverServiceInstaller*.exe" -ErrorAction SilentlyContinue | ForEach-Object {
+    $sizeMb = [math]::Round($_.Length / 1MB, 1)
+    Write-Host ("  {0,-45} {1,6} MB" -f $_.Name, $sizeMb) -ForegroundColor Green
+}
+
+Write-Host ""


### PR DESCRIPTION
UI improvements:
- Dark mode with automatic OS detection and manual toggle (☀/☾)
- Custom flat Button/TextBox ControlTemplates that react to theme switches
- Unsaved changes indicator (* in title) and confirmation on close
- Inline validation (INotifyDataErrorInfo) on source/target folder paths
- Empty state message when no watch folders are configured
- Zebra striping and row numbers on folder list
- Accent (blue) Save button

Bug fixes:
- Save crash (UnauthorizedAccessException): config moved from Program Files to %ProgramData%\FileMoverService — writable by standard users
- Stop/Start service: relaunch self with --elevate runas arg instead of requiring the whole app to run elevated
- Browse button layout: replaced margin hack with proper gap column

Service:
- Renamed from TorrentMoverService to FileMoverService throughout
- Switched IOptions to IOptionsMonitor so config changes apply instantly without restarting the service

Release pipeline:
- build-release.ps1: local script that builds both installer variants
- FileMoverService.iss: #ifdef Bundled guards for dual-installer support
- release.yml: builds and uploads both FileMoverServiceInstaller.exe (~3 MB, requires .NET 10) and FileMoverServiceInstaller-Full.exe (~75 MB, .NET bundled) to the GitHub Release
- .gitignore: exclude publish-* and Output folders