### PR TITLE
Fix uninstaller leaving UI running and blocking reinstall

### DIFF
--- a/FileMoverService.iss
+++ b/FileMoverService.iss
@@ -31,6 +31,10 @@ Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
 PrivilegesRequired=admin
+; Silently close the running UI during install/upgrade so files are not locked
+CloseApplications=yes
+CloseApplicationsFilter=*{#UIExeName}
+RestartApplications=no
 
 SetupIconFile=
 WizardSmallImageFile=
@@ -86,8 +90,14 @@ Filename: "{app}\service\{#AppExeName}"; Parameters: "start";   Flags: runhidden
 Filename: "{app}\ui\{#UIExeName}"; Description: "Launch {#AppName} configuration UI"; Flags: nowait postinstall skipifsilent
 
 [UninstallRun]
-Filename: "{app}\service\{#AppExeName}"; Parameters: "stop";      Flags: runhidden waituntilterminated; RunOnceId: "StopService"
-Filename: "{app}\service\{#AppExeName}"; Parameters: "uninstall"; Flags: runhidden waituntilterminated; RunOnceId: "UninstallService"
+; Kill the tray UI first — it locks files in {app}\ui and keeps the process alive
+Filename: "taskkill.exe";               Parameters: "/F /IM {#UIExeName}";  Flags: runhidden waituntilterminated; RunOnceId: "KillUI"
+Filename: "{app}\service\{#AppExeName}"; Parameters: "stop";                Flags: runhidden waituntilterminated; RunOnceId: "StopService"
+Filename: "{app}\service\{#AppExeName}"; Parameters: "uninstall";           Flags: runhidden waituntilterminated; RunOnceId: "UninstallService"
+
+[UninstallDelete]
+; Remove the entire install directory even if runtime files were left behind
+Type: filesandordirs; Name: "{app}"
 
 [Code]
 // ── .NET check — skipped in the bundled variant ───────────────────────────────


### PR DESCRIPTION
## Summary

- **Uninstaller leaves UI running** — the tray app was never killed during uninstall, so the process kept running in the background even after uninstall completed
- **Reinstall blocked by locked files** — because the UI process was still alive with files open in `{app}\ui`, a fresh install over the top would warn that the app was running and block file replacement
- **Leftover files after uninstall** — Inno Setup only removes files it originally installed; any runtime-generated files left in `{app}` caused the directory to survive uninstall

## Changes (`FileMoverService.iss`)

| Section | Change |
|---|---|
| `[Setup]` | Added `CloseApplications=yes` + `CloseApplicationsFilter=*FileMoverService.UI.exe` + `RestartApplications=no` — installer now silently closes the running UI before copying files during install/upgrade |
| `[UninstallRun]` | Added `taskkill /F /IM FileMoverService.UI.exe` as the **first** step, before stopping and uninstalling the service — ensures the process is fully gone and file locks are released before the uninstaller touches `{app}` |
| `[UninstallDelete]` | Added `Type: filesandordirs; Name: "{app}"` — removes the entire install directory after uninstall, including any files not tracked by the installer |

## Test plan

- [ ] Install the app, let the UI start in the tray
- [ ] Uninstall — UI process should be gone from Task Manager immediately
- [ ] `C:\Program Files\File Mover Service` directory should not exist after uninstall
- [ ] Reinstall without manually closing the UI first — installer should proceed without a blocking warning