### PR TITLE
Fix config not reloading, refactor service, UI polish

### DIFF
--- a/FileMoverService.UI/App.xaml.cs
+++ b/FileMoverService.UI/App.xaml.cs
@@ -147,7 +147,10 @@ public partial class App : Application
     internal void ShowMainWindow()
     {
         if (_mainWindow == null || !_mainWindow.IsLoaded)
+        {
             _mainWindow = new MainWindow();
+            _mainWindow.Icon = CreateWindowIcon();
+        }
 
         // Always Show() — handles both first open and re-show after Hide()
         _mainWindow.Show();
@@ -161,9 +164,9 @@ public partial class App : Application
         base.OnExit(e);
     }
 
-    // ── Tray icon ─────────────────────────────────────────────────────────────
+    // ── Icon ──────────────────────────────────────────────────────────────────
 
-    private static Icon CreateTrayIcon()
+    private static Bitmap CreateIconBitmap()
     {
         var bitmap = new Bitmap(32, 32);
         using var g = Graphics.FromImage(bitmap);
@@ -172,7 +175,28 @@ public partial class App : Application
         g.DrawString("F", new Font("Segoe UI", 14, System.Drawing.FontStyle.Bold), Brushes.White,
             new RectangleF(0, 4, 32, 28),
             new StringFormat { Alignment = StringAlignment.Center });
+        return bitmap;
+    }
+
+    private static Icon CreateTrayIcon()
+    {
+        using var bitmap = CreateIconBitmap();
         return Icon.FromHandle(bitmap.GetHicon());
+    }
+
+    internal static System.Windows.Media.ImageSource CreateWindowIcon()
+    {
+        using var bitmap = CreateIconBitmap();
+        using var ms = new System.IO.MemoryStream();
+        bitmap.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
+        ms.Seek(0, System.IO.SeekOrigin.Begin);
+        var image = new System.Windows.Media.Imaging.BitmapImage();
+        image.BeginInit();
+        image.StreamSource = ms;
+        image.CacheOption = System.Windows.Media.Imaging.BitmapCacheOption.OnLoad;
+        image.EndInit();
+        image.Freeze();
+        return image;
     }
 
     private void TrayOpen_Click(object sender, RoutedEventArgs e) => ShowMainWindow();

--- a/FileMoverService.UI/MainWindow.xaml
+++ b/FileMoverService.UI/MainWindow.xaml
@@ -76,8 +76,8 @@
             </Button>
 
             <Button Grid.Column="4" Content="Add Row" Click="AddRow_Click"/>
-            <Button Grid.Column="6" Content="Save" Click="Save_Click"
-                    Style="{StaticResource PrimaryButton}"/>
+            <Button Grid.Column="6" x:Name="SaveButton" Content="Save" Click="Save_Click"
+                    Style="{StaticResource PrimaryButton}" IsEnabled="False"/>
         </Grid>
 
         <!-- Row list + empty state -->

--- a/FileMoverService.UI/MainWindow.xaml.cs
+++ b/FileMoverService.UI/MainWindow.xaml.cs
@@ -50,12 +50,14 @@ public partial class MainWindow : Window
     {
         _isDirty = true;
         Title = BaseTitle + " *";
+        SaveButton.IsEnabled = true;
     }
 
     private void ClearDirty()
     {
         _isDirty = false;
         Title = BaseTitle;
+        SaveButton.IsEnabled = false;
     }
 
     // ── Button handlers ───────────────────────────────────────────────────────
@@ -100,8 +102,6 @@ public partial class MainWindow : Window
             ConfigService.Save(_entries);
             Logger.Log("Save succeeded");
             ClearDirty();
-            MessageBox.Show("Configuration saved. Changes apply automatically — no service restart needed.",
-                "File Mover Service", MessageBoxButton.OK, MessageBoxImage.Information);
         }
         catch (Exception ex)
         {

--- a/FileMoverService.UI/WatchFolderEntry.cs
+++ b/FileMoverService.UI/WatchFolderEntry.cs
@@ -18,6 +18,7 @@ public class WatchFolderEntry : INotifyPropertyChanged, INotifyDataErrorInfo
             _sourceFolder = value;
             OnPropertyChanged(nameof(SourceFolder));
             Validate(nameof(SourceFolder), value);
+            ValidateSameFolder();
         }
     }
 
@@ -29,6 +30,7 @@ public class WatchFolderEntry : INotifyPropertyChanged, INotifyDataErrorInfo
             _targetFolder = value;
             OnPropertyChanged(nameof(TargetFolder));
             Validate(nameof(TargetFolder), value);
+            ValidateSameFolder();
         }
     }
 
@@ -66,5 +68,38 @@ public class WatchFolderEntry : INotifyPropertyChanged, INotifyDataErrorInfo
 
         ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(property));
         OnPropertyChanged(nameof(HasErrors));
+    }
+
+    private void ValidateSameFolder()
+    {
+        const string key = nameof(TargetFolder);
+        const string msg = "Source and target folders must be different.";
+
+        var src = _sourceFolder?.Trim();
+        var tgt = _targetFolder?.Trim();
+
+        if (!string.IsNullOrWhiteSpace(src) && !string.IsNullOrWhiteSpace(tgt))
+        {
+            bool same;
+            try { same = string.Equals(Path.GetFullPath(src), Path.GetFullPath(tgt), StringComparison.OrdinalIgnoreCase); }
+            catch { same = string.Equals(src, tgt, StringComparison.OrdinalIgnoreCase); }
+
+            if (same)
+            {
+                _errors[key] = [msg];
+                ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(key));
+                OnPropertyChanged(nameof(HasErrors));
+                return;
+            }
+        }
+
+        // Clear same-folder error if it was previously set (leave other errors intact)
+        if (_errors.TryGetValue(key, out var list) && list.Contains(msg))
+        {
+            list.Remove(msg);
+            if (list.Count == 0) _errors.Remove(key);
+            ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(key));
+            OnPropertyChanged(nameof(HasErrors));
+        }
     }
 }

--- a/FileMoverService/AppSettings.cs
+++ b/FileMoverService/AppSettings.cs
@@ -2,8 +2,8 @@ namespace FileMoverService;
 
 public class AppSettings
 {
-    public required List<WatchFolder> WatchFolders { get; init; }
-    public required List<string> TempExtensions { get; init; }
+    public List<WatchFolder> WatchFolders { get; init; } = [];
+    public List<string> TempExtensions { get; init; } = [];
 
     public class WatchFolder
     {

--- a/FileMoverService/FileMonitorService.cs
+++ b/FileMoverService/FileMonitorService.cs
@@ -1,157 +1,200 @@
-using Microsoft.Extensions.Options;
-using System.Threading;
+using System.Text.Json;
 
 namespace FileMoverService;
 
 public class FileMonitorService : BackgroundService
 {
-    private readonly ILogger<FileMonitorService> _logger;
-    private readonly IOptionsMonitor<AppSettings> _optionsMonitor;
-    private readonly SemaphoreSlim _semaphore = new(2);
-    private readonly Lock _watcherLock = new();
-    private List<FileSystemWatcher> _watchers = [];
-    private IDisposable? _changeListener;
+    private static readonly string ConfigPath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+        "FileMoverService", "appsettings.json");
 
-    public FileMonitorService(
-        ILogger<FileMonitorService> logger,
-        IOptionsMonitor<AppSettings> optionsMonitor)
+    private readonly ILogger<FileMonitorService> _logger;
+    private readonly SemaphoreSlim _moveSemaphore = new(2);
+    private readonly object _watcherLock = new();
+
+    private List<FileSystemWatcher> _folderWatchers = [];
+    private AppSettings _settings = new();
+
+    public FileMonitorService(ILogger<FileMonitorService> logger)
     {
         _logger = logger;
-        _optionsMonitor = optionsMonitor;
     }
 
-    public override Task StartAsync(CancellationToken cancellationToken)
+    // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    protected override async Task ExecuteAsync(CancellationToken ct)
     {
-        RebuildWatchers(_optionsMonitor.CurrentValue);
-        _changeListener = _optionsMonitor.OnChange(settings =>
+        _logger.LogInformation("Service starting. Config file: {Path}", ConfigPath);
+        _logger.LogInformation("Config file exists: {Exists}", File.Exists(ConfigPath));
+
+        ApplyConfig(LoadConfig());
+
+        var lastWriteTime = File.Exists(ConfigPath)
+            ? File.GetLastWriteTimeUtc(ConfigPath)
+            : DateTime.MinValue;
+
+        while (!ct.IsCancellationRequested)
         {
-            _logger.LogInformation("Configuration changed, reloading watchers...");
-            RebuildWatchers(settings);
-        });
-        return base.StartAsync(cancellationToken);
+            await Task.Delay(TimeSpan.FromSeconds(2), ct);
+
+            if (!File.Exists(ConfigPath)) continue;
+
+            var writeTime = File.GetLastWriteTimeUtc(ConfigPath);
+            if (writeTime <= lastWriteTime) continue;
+
+            lastWriteTime = writeTime;
+            _logger.LogInformation("Config file changed at {Time}, reloading...", writeTime);
+            ApplyConfig(LoadConfig());
+        }
     }
 
-    public override Task StopAsync(CancellationToken cancellationToken)
+    public override Task StopAsync(CancellationToken ct)
     {
-        _changeListener?.Dispose();
         DisposeWatchers();
-        return base.StopAsync(cancellationToken);
+        return base.StopAsync(ct);
     }
 
-    private void RebuildWatchers(AppSettings settings)
+    // ── Config ────────────────────────────────────────────────────────────────
+
+    private AppSettings LoadConfig()
+    {
+        if (!File.Exists(ConfigPath))
+        {
+            _logger.LogWarning("Config file not found at {Path}, running with no watch folders", ConfigPath);
+            return new AppSettings();
+        }
+
+        try
+        {
+            var json = File.ReadAllText(ConfigPath);
+            using var doc = JsonDocument.Parse(json);
+
+            if (!doc.RootElement.TryGetProperty("AppSettings", out var section))
+            {
+                _logger.LogWarning("Config file has no AppSettings section");
+                return new AppSettings();
+            }
+
+            return JsonSerializer.Deserialize<AppSettings>(
+                section.GetRawText(),
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+                ?? new AppSettings();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to read config from {Path}", ConfigPath);
+            return new AppSettings();
+        }
+    }
+
+    private void ApplyConfig(AppSettings settings)
     {
         lock (_watcherLock)
         {
+            _settings = settings;
             DisposeWatchers();
-            _watchers = [];
+            _folderWatchers = [];
 
-            foreach (var watchFolder in settings.WatchFolders)
+            foreach (var folder in settings.WatchFolders)
             {
-                if (!Directory.Exists(watchFolder.SourceFolder))
+                if (!Directory.Exists(folder.SourceFolder))
                 {
-                    _logger.LogWarning("Watch folder does not exist, skipping: {Folder}", watchFolder.SourceFolder);
+                    _logger.LogWarning("Source folder not found, skipping: {Folder}", folder.SourceFolder);
                     continue;
                 }
 
-                var watcher = new FileSystemWatcher(watchFolder.SourceFolder)
+                var captured = folder;
+                var watcher = new FileSystemWatcher(folder.SourceFolder)
                 {
                     NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite,
                     EnableRaisingEvents = true
                 };
+                watcher.Created += (_, e) => _ = MoveFileAsync(e.FullPath, captured);
+                watcher.Renamed += (_, e) => _ = MoveFileAsync(e.FullPath, captured);
 
-                watcher.Created += (s, e) => Task.Run(() => OnFileSystemEventAsync(s, e, watchFolder));
-                watcher.Renamed += (s, e) => Task.Run(() => OnFileSystemEventAsync(s, e, watchFolder));
-
-                _watchers.Add(watcher);
-                _logger.LogInformation("Watching folder: {Source} -> {Target}", watchFolder.SourceFolder, watchFolder.TargetFolder);
+                _folderWatchers.Add(watcher);
+                _logger.LogInformation("Watching {Source} -> {Target}", folder.SourceFolder, folder.TargetFolder);
             }
+
+            _logger.LogInformation("Config applied: {Count} folder(s) active", _folderWatchers.Count);
         }
     }
 
     private void DisposeWatchers()
     {
-        foreach (var watcher in _watchers)
+        foreach (var w in _folderWatchers)
         {
-            watcher.EnableRaisingEvents = false;
-            watcher.Dispose();
+            w.EnableRaisingEvents = false;
+            w.Dispose();
         }
     }
 
-    private async Task OnFileSystemEventAsync(object sender, FileSystemEventArgs e, AppSettings.WatchFolder watchFolder)
+    // ── File moving ───────────────────────────────────────────────────────────
+
+    private async Task MoveFileAsync(string filePath, AppSettings.WatchFolder folder)
     {
-        await _semaphore.WaitAsync();
+        await _moveSemaphore.WaitAsync();
         try
         {
-            var fileInfo = new FileInfo(e.FullPath);
+            var file = new FileInfo(filePath);
+            if (!file.Exists) return;
 
-            if (IsTemporaryFile(fileInfo))
-                return;
+            AppSettings settings;
+            lock (_watcherLock) settings = _settings;
 
-            if (!watchFolder.Extensions.Any(ext => ext.Equals(fileInfo.Extension, StringComparison.OrdinalIgnoreCase)))
-                return;
+            if (settings.TempExtensions.Contains(file.Extension, StringComparer.OrdinalIgnoreCase)) return;
+            if (file.Length < 1024) return;
+            if (!folder.Extensions.Any(ext => ext.Equals(file.Extension, StringComparison.OrdinalIgnoreCase))) return;
 
-            if (!Path.Exists(watchFolder.TargetFolder))
+            if (!Directory.Exists(folder.TargetFolder))
             {
-                _logger.LogWarning("Target folder does not exist, skipping: {Folder}", watchFolder.TargetFolder);
+                _logger.LogWarning("Target folder not found: {Folder}", folder.TargetFolder);
                 return;
             }
 
-            await WaitForFileToBeUnlockedAsync(fileInfo);
+            await WaitForFileReleaseAsync(file);
 
-            try
-            {
-                var targetPath = GenerateUniqueFileName(Path.Combine(watchFolder.TargetFolder, fileInfo.Name));
-                File.Move(e.FullPath, targetPath);
-                _logger.LogInformation("Moved {File} to {Target}", fileInfo.Name, watchFolder.TargetFolder);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to move file {File}", fileInfo.Name);
-            }
+            var target = UniqueTargetPath(folder.TargetFolder, file.Name);
+            File.Move(filePath, target);
+            _logger.LogInformation("Moved {File} -> {Target}", file.Name, folder.TargetFolder);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to move {File}", filePath);
         }
         finally
         {
-            _semaphore.Release();
+            _moveSemaphore.Release();
         }
     }
 
-    private bool IsTemporaryFile(FileInfo fileInfo) =>
-        _optionsMonitor.CurrentValue.TempExtensions.Contains(fileInfo.Extension) || fileInfo.Length < 1024;
-
-    private bool IsFileLocked(FileInfo file)
+    private static async Task WaitForFileReleaseAsync(FileInfo file)
     {
-        try
+        while (true)
         {
-            using var stream = file.Open(FileMode.Open, FileAccess.Read, FileShare.None);
-            return false;
-        }
-        catch (IOException)
-        {
-            return true;
+            try
+            {
+                using var s = file.Open(FileMode.Open, FileAccess.Read, FileShare.None);
+                return;
+            }
+            catch (IOException)
+            {
+                await Task.Delay(1000);
+            }
         }
     }
 
-    private async Task WaitForFileToBeUnlockedAsync(FileInfo fileInfo)
+    private static string UniqueTargetPath(string dir, string fileName)
     {
-        while (IsFileLocked(fileInfo))
-            await Task.Delay(1000);
-    }
+        var path = Path.Combine(dir, fileName);
+        if (!File.Exists(path)) return path;
 
-    private string GenerateUniqueFileName(string targetPath)
-    {
-        var directory = Path.GetDirectoryName(targetPath);
-        var fileName = Path.GetFileNameWithoutExtension(targetPath);
-        var extension = Path.GetExtension(targetPath);
-        int count = 1;
-
-        while (File.Exists(targetPath))
+        var name = Path.GetFileNameWithoutExtension(fileName);
+        var ext  = Path.GetExtension(fileName);
+        for (var i = 1; ; i++)
         {
-            targetPath = Path.Combine(directory!, $"{fileName}_{count}{extension}");
-            count++;
+            path = Path.Combine(dir, $"{name}_{i}{ext}");
+            if (!File.Exists(path)) return path;
         }
-
-        return targetPath;
     }
-
-    protected override Task ExecuteAsync(CancellationToken stoppingToken) => Task.CompletedTask;
 }

--- a/FileMoverService/FileMoverService.csproj
+++ b/FileMoverService/FileMoverService.csproj
@@ -8,9 +8,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="10.0.0" />
+        <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
+        <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
         <PackageReference Include="Topshelf" Version="4.3.1-develop.253" />
     </ItemGroup>
 </Project>

--- a/FileMoverService/Program.cs
+++ b/FileMoverService/Program.cs
@@ -1,46 +1,41 @@
 using FileMoverService;
+using Serilog;
 using Topshelf;
 
-var builder = Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder(args);
-
-// Load config from %ProgramData%\FileMoverService\appsettings.json so both the
-// service and the UI read/write the same file without needing elevated rights.
-var sharedConfigPath = Path.Combine(
+var logPath = Path.Combine(
     Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-    "FileMoverService", "appsettings.json");
-builder.Configuration.AddJsonFile(sharedConfigPath, optional: true, reloadOnChange: true);
+    "FileMoverService", "logs", "service-.log");
 
-// Configure services
-builder.Services.AddSingleton<IHostedService, FileMonitorService>();
-builder.Services.Configure<AppSettings>(
-    builder.Configuration.GetSection(nameof(AppSettings)));
+Log.Logger = new LoggerConfiguration()
+    .MinimumLevel.Information()
+    .WriteTo.File(
+        logPath,
+        rollingInterval: RollingInterval.Day,
+        retainedFileCountLimit: 14,
+        outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level:u3}] {Message:lj}{NewLine}{Exception}")
+    .CreateLogger();
 
-// Configure Topshelf
+var builder = Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder(args);
+builder.Services.AddHostedService<FileMonitorService>();
+builder.Logging.ClearProviders();
+builder.Logging.AddSerilog();
+
 HostFactory.Run(configurator =>
 {
-    configurator.Service<IHost>(serviceConfigurator =>
+    configurator.Service<IHost>(s =>
     {
-        serviceConfigurator.ConstructUsing(() => 
-            builder.Build());
-        
-        serviceConfigurator.WhenStarted(host => 
-        {
-            Task.Run(() => host.StartAsync()); // Start in a background task
-        });
-
-        serviceConfigurator.WhenStopped(host =>
+        s.ConstructUsing(() => builder.Build());
+        s.WhenStarted(host => Task.Run(() => host.StartAsync()));
+        s.WhenStopped(host =>
         {
             host.StopAsync().GetAwaiter().GetResult();
+            Log.CloseAndFlush();
         });
-
     });
 
-    // Service Configuration
     configurator.RunAsLocalSystem();
     configurator.SetServiceName("FileMoverService");
     configurator.SetDisplayName("File Mover Service");
     configurator.SetDescription("Automatically moves files based on configured rules.");
-
-    // Startup Type
     configurator.StartAutomatically();
 });

--- a/FileMoverService/appsettings.json
+++ b/FileMoverService/appsettings.json
@@ -6,18 +6,6 @@
     }
   },
   "AppSettings": {
-    "TempExtensions": [".tmp", ".crdownload", ".part", ".download"],
-    "WatchFolders": [
-      {
-        "SourceFolder": "C:\\Users\\yourUser\\Downloads",
-        "TargetFolder": "D:\\Organized\\Documents",
-        "Extensions": [".pdf", ".docx", ".txt"]
-      },
-      {
-        "SourceFolder": "C:\\Users\\yourUser\\Desktop",
-        "TargetFolder": "D:\\Organized\\Images",
-        "Extensions": [".jpg", ".png", ".gif"]
-      }
-    ]
+    "TempExtensions": [".tmp", ".crdownload", ".part", ".download"]
   }
 }


### PR DESCRIPTION
## Summary

- Config changes saved from the UI were not being picked up by the running service
- Even restarting the service didn't help due to a .NET config array-merge issue
- FileMonitorService had mixed responsibilities and unreliable change detection

## Root causes

1. **Array merging**: .NET config merges JSON arrays by index. The service-side `appsettings.json` shipped with 2 example `WatchFolders`, so user entries only overrode those indices — leftover example entries survived restarts
2. **Unreliable change detection**: `FileSystemWatcher` on `C:\ProgramData` does not reliably fire when the process runs as `LocalSystem`, so `IOptionsMonitor.OnChange` never triggered

## Changes

### Service
- Replaced `IOptionsMonitor` + `FileSystemWatcher` config detection with **2-second polling on `LastWriteTime`** in `ExecuteAsync` — simple and works reliably as LocalSystem
- Config is now read directly from `C:\ProgramData\FileMoverService\appsettings.json` via `JsonDocument`, bypassing the .NET config pipeline entirely
- Removed `WatchFolders` from the service-side `appsettings.json` — ProgramData is now the sole source, no merging conflicts
- `AppSettings.WatchFolders` / `TempExtensions` are no longer `required` — service starts cleanly with empty defaults
- Added **Serilog file sink** → `C:\ProgramData\FileMoverService\logs\service-YYYYMMDD.log` (14-day rolling)
- Logs config file path, existence, and active folder count on startup and every reload
- `FileMonitorService` refactored: `ExecuteAsync` owns the poll loop, `LoadConfig` owns file reading, `ApplyConfig` owns watcher lifecycle, `MoveFileAsync` owns file moving

### UI
- **Save button** starts disabled; enabled on first change, disabled again after save
- **Window icon** matches the tray icon (same blue circle F bitmap)
- **Same-folder validation** on `WatchFolderEntry` — error shown if source and target are the same path
- **Save success popup removed** — title bar `*` is sufficient feedback

## Test plan
- [x] Install, add a watch folder, save — service log shows reload within 2 seconds
- [x] Restart service — correct folders still active (no ghost example entries)
- [x] Save button disabled on open, enabled after edit, disabled after save
- [x] Window shows blue F icon in taskbar and title bar
- [x] Setting source = target shows validation error on target field
- [x] Check `C:\ProgramData\FileMoverService\logs\` for service log file